### PR TITLE
Static Portrait System: Default Dialog Boxes

### DIFF
--- a/Assets/Fungus/Dialog/Editor/ChooseEditor.cs
+++ b/Assets/Fungus/Dialog/Editor/ChooseEditor.cs
@@ -35,17 +35,6 @@ namespace Fungus
 			serializedObject.Update();
 			
 			Choose t = target as Choose;
-
-			bool showPortraits = false;
-			// Only show portrait selection if...
-			if (t.character != null &&              // Character is selected
-			    t.character.portraits != null &&    // Character has a portraits field
-			    t.character.portraits.Count > 0 &&  // Selected Character has at least 1 portrait
-			    t.chooseDialog != null &&              // Say Dialog is selected
-			    t.chooseDialog.characterImage != null) // Selected Say Dialog has a character image e  
-			{
-				showPortraits = true;         
-			}
 			
 			CommandEditor.ObjectField<Character>(characterProp,
 			                                     new GUIContent("Character", "Character to display in dialog"), 
@@ -57,6 +46,26 @@ namespace Fungus
 			                                        new GUIContent("<Default>"),
 			                                        ChooseDialog.activeDialogs);
 
+			bool showPortraits = false;
+			// Only show portrait selection if...
+			if (t.character != null &&                // Character is selected
+			    t.character.portraits != null &&      // Character has a portraits field
+			    t.character.portraits.Count > 0 )     // Selected Character has at least 1 portrait
+			{
+				ChooseDialog cd = t.chooseDialog;
+				if (t.chooseDialog == null)           // If default box selected
+				{
+					cd = t.character.chooseDialogBox; // Try to get character's default choose dialog box
+					if (t.chooseDialog == null)       // If no default specified, Try to get any ChooseDialog in the scene
+					{
+						cd = GameObject.FindObjectOfType<ChooseDialog>();
+					}
+				}
+				if (cd != null && cd.characterImage != null) // Check that selected choose dialog has a character image
+				{
+					showPortraits = true;    
+				}
+			}			
 			if (showPortraits) 
 			{
 				CommandEditor.ObjectField<Sprite>(portraitProp, 

--- a/Assets/Fungus/Dialog/Editor/SayEditor.cs
+++ b/Assets/Fungus/Dialog/Editor/SayEditor.cs
@@ -57,17 +57,6 @@ namespace Fungus
 
 			Say t = target as Say;
 
-			bool showPortraits = false;
-			// Only show portrait selection if...
-			if (t.character != null &&              // Character is selected
-			    t.character.portraits != null &&    // Character has a portraits field
-			    t.character.portraits.Count > 0 &&  // Selected Character has at least 1 portrait
-			    t.sayDialog != null &&              // Say Dialog is selected
-			    t.sayDialog.characterImage != null) // Selected Say Dialog has a character image 
-			{
-				showPortraits = true;               
-			}
-
 			CommandEditor.ObjectField<Character>(characterProp, 
 			                                     new GUIContent("Character", "Character to display in dialog"), 
 			                                     new GUIContent("<None>"),
@@ -77,6 +66,26 @@ namespace Fungus
 			                                     new GUIContent("Say Dialog", "Say Dialog object to use to display the story text"), 
 			                                     new GUIContent("<Default>"),
 			                                     SayDialog.activeDialogs);
+			bool showPortraits = false;
+			// Only show portrait selection if...
+			if (t.character != null &&              // Character is selected
+			    t.character.portraits != null &&    // Character has a portraits field
+			    t.character.portraits.Count > 0 )   // Selected Character has at least 1 portrait
+			{
+				SayDialog sd = t.sayDialog;
+				if (t.sayDialog == null)            // If default box selected
+				{
+					sd = t.character.sayDialogBox;  // Try to get character's default say dialog box
+					if (t.sayDialog == null)        // If no default specified, try to get any SayDialog in the scene
+					{
+						sd = GameObject.FindObjectOfType<SayDialog>();
+					}
+				}
+				if (sd != null && sd.characterImage != null) // Check that selected say dialog has a character image
+				{
+				    showPortraits = true;    
+				}
+			}
 
 			if (showPortraits) 
 			{

--- a/Assets/FungusExamples/JumpingPrax/JumpingPrax.unity
+++ b/Assets/FungusExamples/JumpingPrax/JumpingPrax.unity
@@ -263,12 +263,11 @@ MonoBehaviour:
     height: 1450
   selectedSequence: {fileID: 16019626}
   selectedCommands:
-  - {fileID: 16019647}
+  - {fileID: 16019627}
   variables: []
   description: 'This scene shows how to control a Unity animation
 
     using trigger parameters. '
-  portraitType: 0
   runSlowDuration: .25
   colorCommands: 1
   hideComponents: 1
@@ -346,11 +345,10 @@ MonoBehaviour:
   storyText: That's me done jumping for now
   character: {fileID: 82341266}
   sayDialog: {fileID: 0}
-  portrait: {fileID: 21300000, guid: 088536216c5364d2ba277595d378c215, type: 3}
+  portrait: {fileID: 0}
   voiceOverClip: {fileID: 0}
   showAlways: 1
   showCount: 1
-  appendToPrev: 0
 --- !u!114 &16019628
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -385,11 +383,10 @@ MonoBehaviour:
   storyText: I don't need shoes, I don't even have feet!
   character: {fileID: 82341266}
   sayDialog: {fileID: 0}
-  portrait: {fileID: 21300000, guid: f2e901e070fff48cda67e3f446d80e79, type: 3}
+  portrait: {fileID: 0}
   voiceOverClip: {fileID: 0}
   showAlways: 1
   showCount: 1
-  appendToPrev: 0
 --- !u!114 &16019643
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -424,11 +421,10 @@ MonoBehaviour:
   storyText: Wait a second...
   character: {fileID: 82341266}
   sayDialog: {fileID: 0}
-  portrait: {fileID: 21300000, guid: a3850401348404655bd0352054c28683, type: 3}
+  portrait: {fileID: 0}
   voiceOverClip: {fileID: 0}
   showAlways: 1
   showCount: 1
-  appendToPrev: 0
 --- !u!114 &16019646
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -461,11 +457,10 @@ MonoBehaviour:
   storyText: I can't find my shoes anywhere!
   character: {fileID: 82341266}
   sayDialog: {fileID: 0}
-  portrait: {fileID: 21300000, guid: d18d934d212d442ee90406fd28e6eef6, type: 3}
+  portrait: {fileID: 0}
   voiceOverClip: {fileID: 0}
   showAlways: 1
   showCount: 1
-  appendToPrev: 0
 --- !u!114 &16019649
 MonoBehaviour:
   m_ObjectHideFlags: 2


### PR DESCRIPTION
Just one minor change. I fixed a bug where portrait field is hidden if the default dialog box is selected. The portrait system should work correctly with default dialog boxes now.
