### PR TITLE
Stop all executing blocks on play selected

### DIFF
--- a/Assets/Fungus/Flowchart/Editor/BlockEditor.cs
+++ b/Assets/Fungus/Flowchart/Editor/BlockEditor.cs
@@ -830,6 +830,7 @@ namespace Fungus
             if (showPlay)
             {
                 commandMenu.AddItem(new GUIContent("Play from selected"), false, PlayCommand);
+                commandMenu.AddItem(new GUIContent("Stop all and play"), false, StopAllPlayCommand);
             }
 
             commandMenu.AddSeparator("");
@@ -1036,6 +1037,17 @@ namespace Fungus
                 // Block isn't executing yet so can start it now.
                 flowchart.ExecuteBlock(targetBlock, command.commandIndex);
             }
+        }
+
+        protected void StopAllPlayCommand()
+        {
+            Block targetBlock = target as Block;
+            Flowchart flowchart = targetBlock.GetFlowchart();
+            Command command = flowchart.selectedCommands[0];
+
+            // Stop all active blocks then run the selected block.
+            flowchart.StopAllBlocks();
+            flowchart.StartCoroutine(RunBlock(flowchart, targetBlock, command.commandIndex, 0.2f));
         }
 
         protected IEnumerator RunBlock(Flowchart flowchart, Block targetBlock, int commandIndex, float delay)


### PR DESCRIPTION
Quick bugfix: If there is another block executing, and then you use the "play selected" command on a non-executing block, both blocks will execute at the same time. I changed it so that it will stop all executing blocks before executing the selected block. 