### PR TITLE
No Music clip selected error

### DIFF
--- a/Assets/Fungus/Audio/Scripts/Commands/PlaySound.cs
+++ b/Assets/Fungus/Audio/Scripts/Commands/PlaySound.cs
@@ -52,7 +52,7 @@ namespace Fungus
 		{
 			if (soundClip == null)
 			{
-				return "Error: No music clip selected";
+				return "Error: No sound clip selected";
 			}
 
 			return soundClip.name;


### PR DESCRIPTION
Changed to 'No sound clip selected', could make both more universal and say no audio clip selected.