### PR TITLE
Bugfix for when portrait field is blank

### DIFF
--- a/Assets/Fungus/Narrative/Scripts/Character.cs
+++ b/Assets/Fungus/Narrative/Scripts/Character.cs
@@ -80,7 +80,7 @@ namespace Fungus
 
             for (int i = 0; i < portraits.Count; i++)
             {
-                if ( String.Compare(portraits[i].name, portrait_string, true) == 0)
+                if (portraits[i] != null && String.Compare(portraits[i].name, portrait_string, true) == 0)
                 {
                     return portraits[i];
                 }


### PR DESCRIPTION
In the portrait lookup, if you have a blank portrait field on a character, it blows up. This prevents it by checking if there is a portrait to compare against first.