### PR TITLE
Sync active say dialog when Lua sets the say dialog

### DIFF
--- a/Assets/Fungus/Thirdparty/FungusLua/Resources/Lua/fungus.txt
+++ b/Assets/Fungus/Thirdparty/FungusLua/Resources/Lua/fungus.txt
@@ -146,6 +146,7 @@ M.sayoptions.stopvoiceover = true
 -- Set the active saydialog to use with the say function
 function M.setsaydialog(saydialog)
 	M.sayoptions.saydialog = saydialog
+	luautils.SyncSayDialog(saydialog)
 end
 
 -- Gets the active say dialog, or creates one if none exists yet

--- a/Assets/Fungus/Thirdparty/FungusLua/Scripts/LuaUtils.cs
+++ b/Assets/Fungus/Thirdparty/FungusLua/Scripts/LuaUtils.cs
@@ -480,6 +480,15 @@ namespace Fungus
 		{
 			return conversationManager.DoConversation(conv);
 		}
+
+		/// <summary>
+		/// Sync the active say dialog with what Lua thinks the SayDialog should be
+		/// </summary>
+		/// <param name="sayDialog"></param>
+		public void SyncSayDialog(SayDialog sayDialog)
+		{
+			SayDialog.activeSayDialog = sayDialog;
+		}
    }
 
 }


### PR DESCRIPTION
There was a disconnect between Lua's setsaydialog and c#'s SayDialog.activeSayDialog. I did the simplest thing and made a sync function in luaUtils. Maybe not the fanciest solution but it works.