### PR TITLE
Fix Regex for character names with "." & "'"

### DIFF
--- a/Assets/Fungus/Narrative/Scripts/ConversationManager.cs
+++ b/Assets/Fungus/Narrative/Scripts/ConversationManager.cs
@@ -164,7 +164,7 @@ namespace Fungus
         {
             //find SimpleScript say strings with portrait options
             //You can test regex matches here: http://regexstorm.net/tester
-            var sayRegex = new Regex(@"((?<sayParams>[\w ""><]*):)?(?<text>.*)\r*(\n|$)");
+            var sayRegex = new Regex(@"((?<sayParams>[\w ""><.']*):)?(?<text>.*)\r*(\n|$)");
             MatchCollection sayMatches = sayRegex.Matches(conv);
 
             var items = new List<ConversationItem>(sayMatches.Count);


### PR DESCRIPTION
Old Regex expression did not capture Character names with "." and "'". As a result characters with names like "Mr. Jones" or "Ab'ar" were not registering correctly.

I added . & ' characters into Regex. We may need to add some more characters in future.