### PR TITLE
Flowchart window improvements - keyboard shortcuts and context menu updates

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -42,6 +42,7 @@ namespace Fungus.EditorUtils
         // Context Click occurs on MouseDown which interferes with panning
         // Track right click positions manually to show menus on MouseUp
         protected Vector2 rightClickDown = -Vector2.one;
+        protected readonly float rightClickTolerance = 5f;
 
         [MenuItem("Tools/Fungus/Flowchart Window")]
         static void Init()
@@ -310,7 +311,10 @@ namespace Fungus.EditorUtils
                 }
                 else if (Event.current.type == EventType.MouseDrag)
                 {
-                    rightClickDown = -Vector2.one;
+                    if (Vector2.Distance(rightClickDown, Event.current.mousePosition) > rightClickTolerance)
+                    {
+                        rightClickDown = -Vector2.one;
+                    }
                 }
             }
 
@@ -487,7 +491,7 @@ namespace Fungus.EditorUtils
             
             // Handle right click up outside of EditorZoomArea to avoid strange offsets
             if (Event.current.type == EventType.MouseUp && Event.current.button == 1 &&
-                Event.current.mousePosition == rightClickDown && !mouseOverVariables)
+                rightClickDown != -Vector2.one && !mouseOverVariables)
             {
                 var menu = new GenericMenu();
                 var mousePosition = rightClickDown;

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -210,7 +210,10 @@ namespace Fungus.EditorUtils
             );
             GUILayout.Label(flowchart.Zoom.ToString("0.0#x"), EditorStyles.miniLabel, GUILayout.Width(30));
 
-            DoZoom(flowchart, newZoom - flowchart.Zoom, Vector2.one * 0.5f);
+            if (newZoom != flowchart.Zoom)
+            {
+                DoZoom(flowchart, newZoom - flowchart.Zoom, Vector2.one * 0.5f);
+            }
 
             if (GUILayout.Button("Center", EditorStyles.toolbarButton))
             {


### PR DESCRIPTION
See #225

Added duplicate, delete, and select all commands. Also added relevant commands to the block context menu and added new context menu with an add new block option.

In order to support a right-click context menu when clicking on the background while still being able to drag and pan, I moved showing the context menu from `EventType.ContextClick` to `EventType.MouseUp`, because `EventType.ContextClick` occurs on mouse down (at least on macOS). Unfortunately, there is some magic that happens before or during the `ContextClick` event, so the new context menus have slightly smaller text than before. I'm not really sure how to change this, but it seems fine regardless.

By the way--I did do the pro icons in another branch as discussed, but I want to try out one more idea before I do a PR with them.