### PR TITLE
Refactor EventHandler notification in order to avoid FindObjectsOfType calls

### DIFF
--- a/Assets/Fungus/Scripts/Components/Clickable2D.cs
+++ b/Assets/Fungus/Scripts/Components/Clickable2D.cs
@@ -39,13 +39,7 @@ namespace Fungus
                 return;
             }
 
-            // TODO: Cache these objects for faster lookup
-            var handlers = GameObject.FindObjectsOfType<ObjectClicked>();
-            for (int i = 0; i < handlers.Length; i++)
-            {
-                var handler = handlers[i];
-                handler.OnObjectClicked(this);
-            }
+            EventDispatcher.Raise(new ObjectClicked.ObjectClickedEvent(this));
         }
 
         protected virtual void DoPointerEnter()

--- a/Assets/Fungus/Scripts/Components/Draggable2D.cs
+++ b/Assets/Fungus/Scripts/Components/Draggable2D.cs
@@ -57,20 +57,7 @@ namespace Fungus
             {
                 return;
             }
-
-            var dragEnteredHandlers = GetHandlers<DragEntered>();
-            for (int i = 0; i < dragEnteredHandlers.Length; i++)
-            {
-                var handler = dragEnteredHandlers[i];
-                handler.OnDragEntered(this, other);
-            }
-
-            var dragCompletedHandlers = GetHandlers<DragCompleted>();
-            for (int i = 0; i < dragCompletedHandlers.Length; i++)
-            {
-                var handler = dragCompletedHandlers[i];
-                handler.OnDragEntered(this, other);
-            }
+            EventDispatcher.Raise(new DragEntered.DragEnteredEvent(this, other));
         }
 
         protected virtual void OnTriggerExit2D(Collider2D other) 
@@ -79,20 +66,7 @@ namespace Fungus
             {
                 return;
             }
-
-            var dragExitedHandlers = GetHandlers<DragExited>();
-            for (int i = 0; i < dragExitedHandlers.Length; i++)
-            {
-                var handler = dragExitedHandlers[i];
-                handler.OnDragExited(this, other);
-            }
-
-            var dragCompletedHandlers = GetHandlers<DragCompleted>();
-            for (int i = 0; i < dragCompletedHandlers.Length; i++)
-            {
-                var handler = dragCompletedHandlers[i];
-                handler.OnDragExited(this, other);
-            }
+            EventDispatcher.Raise(new DragExited.DragExitedEvent(this, other));
         }
 
         protected virtual T[] GetHandlers<T>() where T : EventHandler
@@ -111,12 +85,7 @@ namespace Fungus
 
             startingPosition = transform.position;
 
-            var dragStartedHandlers = GetHandlers<DragStarted>();
-            for (int i = 0; i < dragStartedHandlers.Length; i++)
-            {
-                var handler = dragStartedHandlers[i];
-                handler.OnDragStarted(this);
-            }
+            EventDispatcher.Raise(new DragStarted.DragStartedEvent(this));
         }
 
         protected virtual void DoDrag()
@@ -152,7 +121,7 @@ namespace Fungus
                 {
                     if (handler.IsOverTarget())
                     {
-                        handler.OnDragCompleted(this);
+                        EventDispatcher.Raise(new DragCompleted.DragCompletedEvent(this));
                         dragCompleted = true;
                         if (returnOnCompleted)
                         {
@@ -164,12 +133,7 @@ namespace Fungus
 
             if (!dragCompleted)
             {
-                var dragCancelledHandlers = GetHandlers<DragCancelled>();
-                for (int i = 0; i < dragCancelledHandlers.Length; i++)
-                {
-                    var handler = dragCancelledHandlers[i];
-                    handler.OnDragCancelled(this);
-                }
+                EventDispatcher.Raise(new DragCancelled.DragCancelledEvent(this));
 
                 if (returnOnCancelled)
                 {

--- a/Assets/Fungus/Scripts/Components/EventHandler.cs
+++ b/Assets/Fungus/Scripts/Components/EventHandler.cs
@@ -41,6 +41,38 @@ namespace Fungus
         [FormerlySerializedAs("parentSequence")]
         [SerializeField] protected Block parentBlock;
 
+        #region Unity Messages Propagation
+        protected virtual void UnityOnEnable()
+        {
+
+        }
+
+        protected virtual void UnityOnDisable()
+        {
+
+        }
+
+        protected virtual void UnityStart()
+        {
+
+        }
+
+        void OnEnable()
+        {
+            UnityOnEnable();
+        }
+
+        void OnDisable()
+        {
+            UnityOnDisable();
+        }
+
+        void Start()
+        {
+            UnityStart();
+        }
+        #endregion
+
         #region Public members
 
         /// <summary>

--- a/Assets/Fungus/Scripts/EventHandlers/DragCancelled.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragCancelled.cs
@@ -14,9 +14,34 @@ namespace Fungus
     [AddComponentMenu("")]
     public class DragCancelled : EventHandler
     {   
+        public class DragCancelledEvent
+        {
+            public Draggable2D DraggableObject;
+            public DragCancelledEvent(Draggable2D draggableObject)
+            {
+                DraggableObject = draggableObject;
+            }
+        }
+
         [Tooltip("Draggable object to listen for drag events on")]
         [SerializeField] protected Draggable2D draggableObject;
 
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<DragCancelledEvent>(OnDragCancelledEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<DragCancelledEvent>(OnDragCancelledEvent);
+        }
+
+        void OnDragCancelledEvent(DragCancelledEvent evt)
+        {
+            OnDragCancelled(evt.DraggableObject);
+        }
         #region Public members
 
         public virtual void OnDragCancelled(Draggable2D draggableObject)

--- a/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
@@ -14,6 +14,14 @@ namespace Fungus
     [AddComponentMenu("")]
     public class DragCompleted : EventHandler
     {   
+        public class DragCompletedEvent
+        {
+            public Draggable2D DraggableObject;
+            public DragCompletedEvent(Draggable2D draggableObject)
+            {
+                DraggableObject = draggableObject;
+            }
+        }
         [Tooltip("Draggable object to listen for drag events on")]
         [SerializeField] protected Draggable2D draggableObject;
 
@@ -23,6 +31,37 @@ namespace Fungus
         // There's no way to poll if an object is touching another object, so
         // we have to listen to the callbacks and track the touching state ourselves.
         protected bool overTarget = false;
+
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<DragCompletedEvent>(OnDragCompletedEvent);
+            EventDispatcher.AddListener<DragEntered.DragEnteredEvent>(OnDragEnteredEvent);
+            EventDispatcher.AddListener<DragExited.DragExitedEvent>(OnDragExitedEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<DragCompletedEvent>(OnDragCompletedEvent);
+            EventDispatcher.RemoveListener<DragEntered.DragEnteredEvent>(OnDragEnteredEvent);
+            EventDispatcher.RemoveListener<DragExited.DragExitedEvent>(OnDragExitedEvent);
+        }
+
+        void OnDragCompletedEvent(DragCompletedEvent evt)
+        {
+            OnDragCompleted(evt.DraggableObject);
+        }
+
+        void OnDragEnteredEvent(DragEntered.DragEnteredEvent evt)
+        {
+            OnDragEntered(evt.DraggableObject, evt.TargetCollider);
+        }
+
+        void OnDragExitedEvent(DragExited.DragExitedEvent evt)
+        {
+            OnDragExited(evt.DraggableObject, evt.TargetCollider);
+        }
 
         #region Public members
 

--- a/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
@@ -38,6 +38,11 @@ namespace Fungus
             EventDispatcher.AddListener<DragCompletedEvent>(OnDragCompletedEvent);
             EventDispatcher.AddListener<DragEntered.DragEnteredEvent>(OnDragEnteredEvent);
             EventDispatcher.AddListener<DragExited.DragExitedEvent>(OnDragExitedEvent);
+
+            if(draggableObject != null)
+            {
+                draggableObject.RegisterHandler(this);
+            }
         }
 
         protected override void UnityOnDisable()
@@ -45,7 +50,12 @@ namespace Fungus
             base.UnityOnDisable();
             EventDispatcher.RemoveListener<DragCompletedEvent>(OnDragCompletedEvent);
             EventDispatcher.RemoveListener<DragEntered.DragEnteredEvent>(OnDragEnteredEvent);
-            EventDispatcher.RemoveListener<DragExited.DragExitedEvent>(OnDragExitedEvent);
+            EventDispatcher.RemoveListener<DragExited.DragExitedEvent>(OnDragExitedEvent);            
+
+            if(draggableObject != null)
+            {
+                draggableObject.UnregisterHandler(this);
+            }
         }
 
         void OnDragCompletedEvent(DragCompletedEvent evt)

--- a/Assets/Fungus/Scripts/EventHandlers/DragEntered.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragEntered.cs
@@ -17,12 +17,38 @@ namespace Fungus
     [AddComponentMenu("")]
     public class DragEntered : EventHandler
     {   
+        public class DragEnteredEvent
+        {
+            public Draggable2D DraggableObject;
+            public Collider2D TargetCollider;
+            public DragEnteredEvent(Draggable2D draggableObject, Collider2D targetCollider)
+            {
+                DraggableObject = draggableObject;
+                TargetCollider = targetCollider;
+            }
+        }
         [Tooltip("Draggable object to listen for drag events on")]
         [SerializeField] protected Draggable2D draggableObject;
 
         [Tooltip("Drag target object to listen for drag events on")]
         [SerializeField] protected Collider2D targetObject;
 
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<DragEnteredEvent>(OnDragEnteredEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<DragEnteredEvent>(OnDragEnteredEvent);
+        }
+
+        void OnDragEnteredEvent(DragEnteredEvent evt)
+        {
+            OnDragEntered(evt.DraggableObject, evt.TargetCollider);
+        }
         #region Public members
 
         /// <summary>

--- a/Assets/Fungus/Scripts/EventHandlers/DragExited.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragExited.cs
@@ -17,11 +17,39 @@ namespace Fungus
     [AddComponentMenu("")]
     public class DragExited : EventHandler
     {   
+        public class DragExitedEvent
+        {
+            public Draggable2D DraggableObject;
+            public Collider2D TargetCollider;
+            public DragExitedEvent(Draggable2D draggableObject, Collider2D targetCollider)
+            {
+                DraggableObject = draggableObject;
+                TargetCollider = targetCollider;
+            }
+        }
+
         [Tooltip("Draggable object to listen for drag events on")]
         [SerializeField] protected Draggable2D draggableObject;
 
         [Tooltip("Drag target object to listen for drag events on")]
         [SerializeField] protected Collider2D targetObject;
+
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<DragExitedEvent>(OnDragEnteredEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<DragExitedEvent>(OnDragEnteredEvent);
+        }
+
+        void OnDragEnteredEvent(DragExitedEvent evt)
+        {
+            OnDragExited(evt.DraggableObject, evt.TargetCollider);
+        }
 
         #region Public members
 

--- a/Assets/Fungus/Scripts/EventHandlers/DragStarted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragStarted.cs
@@ -14,7 +14,33 @@ namespace Fungus
     [AddComponentMenu("")]
     public class DragStarted : EventHandler
     {   
+        public class DragStartedEvent
+        {
+            public Draggable2D DraggableObject;
+            public DragStartedEvent(Draggable2D draggableObject)
+            {
+                DraggableObject = draggableObject;
+            }
+        }
+
         [SerializeField] protected Draggable2D draggableObject;
+
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<DragStartedEvent>(OnDragStartedEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<DragStartedEvent>(OnDragStartedEvent);
+        }
+
+        void OnDragStartedEvent(DragStartedEvent evt)
+        {
+            OnDragStarted(evt.DraggableObject);
+        }
 
         #region Public members
 

--- a/Assets/Fungus/Scripts/EventHandlers/EventDispatcher.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/EventDispatcher.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections.Generic;
+using System;
+
+namespace Fungus
+{
+    public class EventDispatcher 
+    {
+        public delegate void TypedDelegate<T>(T e) where T : class;
+
+        #region Statics
+        static EventDispatcher _instance;
+        public static EventDispatcher Instance
+        {
+            get
+            {
+                if(_instance == null)
+                {
+                    _instance = new EventDispatcher();
+                }
+                return _instance;
+            }
+        }
+
+        public static void AddLog(Action<string> log)
+        {
+            Instance.addLog(log);
+        }
+
+        public static void RemoveLog(Action<string> log)
+        {
+            Instance.removeLog(log);
+        }
+
+        public static void AddListener<T>(TypedDelegate<T> listener) where T : class
+        {
+            Instance.addListener(listener);
+        }
+
+        public static void RemoveListener<T>(TypedDelegate<T> listener) where T : class
+        {
+            Instance.removeListener(listener);
+        }
+
+        public static void Raise<T>(T evt) where T : class
+        {
+            Instance.raise(evt);
+        }
+
+        public static void Raise<T>() where T : class, new()
+        {
+            Instance.raise<T>(new T());
+        }
+
+        public static void UnregisterAll()
+        {
+            Instance.unregisterAll();
+        }
+        #endregion
+
+        #region Private Members
+        readonly Dictionary<Type, List<Delegate>> _delegates;
+        event Action<string> _onLog;
+        #endregion
+
+        #region Private Functions
+        private EventDispatcher()
+        {
+            _delegates = new Dictionary<Type, List<Delegate>>();
+        }
+        /// <summary>
+        /// Gets the delegate list copy.
+        /// </summary>
+        /// <remarks>
+        /// As listener can modify the list while iterating it, it is better to iterate a copy of the delegates list instead of a reference.
+        /// </remarks>
+        /// <returns>A copy of the delegates list if found. Null if the dictionary does not contain a delegate list for this event.</returns>
+        /// <param name="evt">Event instance.</param>
+        /// <typeparam name="T">Type of the received event.</typeparam>
+        List<Delegate> getDelegateListCopy<T>(T evt)
+        {
+            var type = typeof(T);
+            return _delegates.ContainsKey(type) ? new List<Delegate>(_delegates[type]) : null;
+        }
+
+        void log(string message)
+        {
+            if(_onLog != null)
+            {
+                _onLog(message);
+            }
+        }
+        #endregion
+
+        #region Public Functions
+        public void addLog(Action<string> log)
+        {
+            _onLog += log;
+        }
+
+        public void removeLog(Action<string> log)
+        {
+            _onLog -= log;
+        }
+
+        public void addListener<T>(TypedDelegate<T> listener) where T : class
+        {
+            var type = typeof(T);
+            if(!_delegates.ContainsKey(type))
+            {
+                _delegates.Add(type, new List<Delegate>());
+            }
+
+            var list = _delegates[type];
+            if(!list.Contains(listener))
+            {
+                list.Add(listener);
+            }
+        }
+
+        public void removeListener<T>(TypedDelegate<T> listener) where T : class
+        {
+            var type = typeof(T);
+            if(_delegates.ContainsKey(type))
+            {
+                _delegates[type].Remove(listener);
+                return;
+            }
+        }
+
+        public void raise<T>(T evt) where T : class
+        {
+            if(evt == null)
+            {
+                log("Raised a null event");
+                return;
+            }
+
+            var list = getDelegateListCopy(evt);
+            if(list == null || list.Count < 1)
+            {
+                log("Raised an event with no listeners");
+                return;
+            }
+
+            for(int i = 0; i < list.Count; ++i)
+            {
+                var callback = list[i] as TypedDelegate<T>;
+
+                if(callback != null)
+                {
+                    try
+                    {
+                        callback(evt);
+                    }
+                    catch(Exception gotcha)
+                    {
+                        log(gotcha.Message);
+                    }
+                }
+            }
+        }
+
+        public void raise<T>() where T : class, new()
+        {
+            raise<T>(new T());
+        }
+
+        public void unregisterAll()
+        {
+            _delegates.Clear();
+        }
+        #endregion
+    }
+}

--- a/Assets/Fungus/Scripts/EventHandlers/EventDispatcher.cs.meta
+++ b/Assets/Fungus/Scripts/EventHandlers/EventDispatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d6bacc8888852c94bab5c3b36cdf1574
+timeCreated: 1483696929
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/EventHandlers/FlowchartEnabled.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/FlowchartEnabled.cs
@@ -14,8 +14,9 @@ namespace Fungus
     [AddComponentMenu("")]
     public class FlowchartEnabled : EventHandler
     {   
-        protected virtual void OnEnable()
+        protected override void UnityOnEnable()
         {
+            base.UnityOnEnable();
             // Blocks use coroutines to schedule command execution, but Unity's coroutines are
             // sometimes unreliable when enabling / disabling objects.
             // To workaround this we execute the block on the next frame.

--- a/Assets/Fungus/Scripts/EventHandlers/GameStarted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/GameStarted.cs
@@ -18,7 +18,13 @@ namespace Fungus
         [Tooltip("Wait for a number of frames after startup before executing the Block. Can help fix startup order issues.")]
         [SerializeField] protected int waitForFrames = 1;
 
-        protected virtual IEnumerator Start()
+        protected override void UnityStart()
+        {
+            base.UnityStart();
+            StartCoroutine(GameStartCoroutine());
+        }
+
+        protected virtual IEnumerator GameStartCoroutine()
         {
             int frameCount = waitForFrames;
             while (frameCount > 0)

--- a/Assets/Fungus/Scripts/EventHandlers/ObjectClicked.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/ObjectClicked.cs
@@ -15,11 +15,38 @@ namespace Fungus
     [AddComponentMenu("")]
     public class ObjectClicked : EventHandler
     {   
+        public class ObjectClickedEvent
+        {
+            public Clickable2D ClickableObject;
+            public ObjectClickedEvent(Clickable2D clickableObject)
+            {
+                ClickableObject = clickableObject;
+            }
+        }
+
         [Tooltip("Object that the user can click or tap on")]
         [SerializeField] protected Clickable2D clickableObject;
 
         [Tooltip("Wait for a number of frames before executing the block.")]
         [SerializeField] protected int waitFrames = 1;
+
+
+        protected override void UnityOnEnable()
+        {
+            base.UnityOnEnable();
+            EventDispatcher.AddListener<ObjectClickedEvent>(OnObjectClickedEvent);
+        }
+
+        protected override void UnityOnDisable()
+        {
+            base.UnityOnDisable();
+            EventDispatcher.RemoveListener<ObjectClickedEvent>(OnObjectClickedEvent);
+        }
+
+        void OnObjectClickedEvent(ObjectClickedEvent evt)
+        {
+            OnObjectClicked(evt.ClickableObject);
+        }
 
         /// <summary>
         /// Executing a block on the same frame that the object is clicked can cause


### PR DESCRIPTION
FindObjectsOfType is an expensive call and it is being called for each event in Draggable2D and Clickable2D. 

In order to avoid them I considered 2 options:
 - Register and unregister the Handlers to the desired object, so the object would notify directly to the EventHanldlers. I've implemented this when the object needs to access the Handler.

 - Register the handlers to an EventDispatcher and raise events from the object. I decided to implement this because with the EventDispatcher we can make it more isolated, only registered objects would listen to events, and multiple objects can listen to a certain event avoiding multiple references in objects. Also this way of dispatching events can be reused in multiple places.