### PR TITLE
Add Missile Command Scene and Commands and Events

### DIFF
--- a/Assets/Fungus/Scripts/Commands/Destroy.cs
+++ b/Assets/Fungus/Scripts/Commands/Destroy.cs
@@ -18,6 +18,7 @@ namespace Fungus
     {   
         [Tooltip("Reference to game object to destroy")]
         [SerializeField] protected GameObjectData _targetGameObject;
+        [SerializeField] protected bool self;
 
         #region Public members
 
@@ -28,16 +29,25 @@ namespace Fungus
                 Destroy(_targetGameObject.Value);
             }
 
+            if (self)
+            {
+                Destroy(gameObject);
+            }
+
             Continue();
         }
 
         public override string GetSummary()
         {
-            if (_targetGameObject.Value == null)
+            if (_targetGameObject.Value == null && !self)
             {
                 return "Error: No game object selected";
             }
 
+            if (self)
+            {
+                return "Destroy this game object";
+            }
             return _targetGameObject.Value.name;
         }
 

--- a/Assets/Fungus/Scripts/Commands/FindGameObject.cs
+++ b/Assets/Fungus/Scripts/Commands/FindGameObject.cs
@@ -1,0 +1,45 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Finds an game object with tag and returns a random game object to the specified variable
+    /// </summary>
+    [CommandInfo("Scripting",
+        "Find Game Objects With Tag",
+        "Find game objects with a tag and select a random one out of them")]
+
+
+    [AddComponentMenu("")]
+    public class FindGameObject : Command
+    {
+        [VariableProperty(typeof(GameObjectVariable))]
+        [SerializeField]
+        protected Variable targetGameObject;
+
+        [Tooltip("Input text or a string variable")]
+        [SerializeField]
+        protected StringData objectTagName;
+
+        public override void OnEnter()
+        {
+            if (targetGameObject == null)
+            {
+                return;
+            }
+
+            GameObject[] varArray = GameObject.FindGameObjectsWithTag(objectTagName);
+            if (varArray.Length == 0)
+            {
+                return;
+            }
+            else
+            {
+                GameObjectVariable gameobject = (targetGameObject as GameObjectVariable);
+                gameobject.Value = varArray[Random.Range(0, varArray.Length)];
+            }
+
+            Continue();
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/FindGameObject.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/FindGameObject.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: d08722ab82537ee4ab3b45e527b9924d
+timeCreated: 1503275131
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/GetClosestGameObjectWithTag.cs
+++ b/Assets/Fungus/Scripts/Commands/GetClosestGameObjectWithTag.cs
@@ -1,0 +1,57 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Find the closest game object with specified tag to a Vector3 location
+    /// </summary>
+    [CommandInfo("Scripting",
+                  "Get Closest Game Object With Tag",
+                  "Sets a variable with the closest object from a point")]
+
+    [AddComponentMenu("")]
+    public class GetClosestGameObject : Command
+    {
+
+        [Tooltip("Location of point origin")]
+        [SerializeField]
+        protected Vector3Data location;
+
+        [Tooltip("Closest Game Object With Tag")]
+        [SerializeField]
+        protected GameObjectData targetGameObject;
+
+        [SerializeField]
+        protected string Tag;
+
+        [SerializeField]
+        protected float maxRange;
+
+        public override void OnEnter()
+        {
+            //Retrieve all game objects with tag
+            GameObject[] list = GameObject.FindGameObjectsWithTag(Tag);
+            GameObject closest = null;
+            float minDist = maxRange;
+            //Iterate through game objects list and find closest to position.
+            for (int i = 0; i < list.Length; i++)
+            {
+                float distance = Vector3.Distance(location.Value, list[i].transform.position);
+                if (minDist > distance)
+                {
+                    minDist = distance;
+                    closest = list[i];
+                }
+            }
+
+            if (closest == null)
+            {
+                return;
+            }
+
+            targetGameObject.Value = closest;
+
+            Continue();
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/GetClosestGameObjectWithTag.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/GetClosestGameObjectWithTag.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 665c1943fb77f86458ce048845fe3485
+timeCreated: 1503275330
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/GetCurrentPosition.cs
+++ b/Assets/Fungus/Scripts/Commands/GetCurrentPosition.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Gets the current Vector3 position of game object attached and return it to a variable
+    /// </summary>
+    [CommandInfo("Scripting", "Get Current Position", "Gets the current Vector3 position of attached gameObject and assigns it to a variable")]
+    public class GetCurrentPosition : Command
+    {
+        #region Public members
+
+        [VariableProperty(typeof(Vector3Variable))]
+        [SerializeField]
+        protected Variable currentPosition;
+
+        public override void OnEnter()
+        {
+            if (currentPosition == null)
+            {
+                return;
+            }
+
+            (currentPosition as Vector3Variable).Value = this.gameObject.transform.position;
+
+            Continue();
+        }
+
+        public override string GetSummary()
+        {
+            if (currentPosition == null)
+            {
+                return "Error: There is no variable currently selected";
+            }
+
+            return "Returning current position into the variable " + currentPosition.name;
+        }
+        #endregion
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/GetCurrentPosition.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/GetCurrentPosition.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: d81bc03424c92d54d9a2e2b817044021
+timeCreated: 1503275479
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/GetCursorPosition.cs
+++ b/Assets/Fungus/Scripts/Commands/GetCursorPosition.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Gets the current cursor position and return it to a Vector3Variable
+    /// </summary>
+    [CommandInfo("Scripting",
+                  "Get Cursor Position",
+                  "Sets the cursors position as a vector 3 variable")]
+
+    [AddComponentMenu("")]
+    public class GetCursorPosition : Command
+    {
+
+        [Tooltip("Input text or a string variable")]
+        [SerializeField]
+        protected Vector3Data cursorPosition;
+
+        protected Vector3 planePoint = new Vector3(0, 0, 0);
+        protected Vector3 planeNormal = new Vector3(0, 0, 1);
+
+        public override void OnEnter()
+        {
+            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+
+            float dist;
+            Plane p = new Plane(planeNormal, planePoint);
+            p.Raycast(ray, out dist);
+
+            cursorPosition.Value = ray.GetPoint(dist);
+
+            Continue();
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/GetCursorPosition.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/GetCursorPosition.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: ece6ccf34d01870418adea815e86dfcf
+timeCreated: 1503275647
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/MoveToComplex.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveToComplex.cs
@@ -1,0 +1,85 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    public enum VariableType
+    {
+        Vector3,
+        Transform,
+        GameObject
+    }
+
+    /// <summary>
+    /// Move towards an object with a specified speed
+    /// </summary>
+    [CommandInfo("Scripting",
+                "MoveToObject",
+                "Move towards an object at a speed that is specified.")]
+    public class MoveToComplex : Command
+    {
+        [VariableProperty(typeof(TransformVariable),
+                        typeof(Vector3Variable),
+                        typeof(GameObjectVariable))]
+        [SerializeField]
+        protected Variable variable;
+
+        [Tooltip("The speed that will be move the object in every frame")]
+        public float speed;
+
+        private bool started = false;
+        private Vector3 target;
+
+        public override void OnEnter()
+        {
+            DoSetOperation();
+        }
+
+        protected virtual void DoSetOperation()
+        {
+            //Identify target variable
+            if (variable == null)
+            {
+                return;
+            }
+
+            if (variable.GetType() == typeof(Vector3Variable))
+            {
+                target = (variable as Vector3Variable).Value;
+            }
+            else if (variable.GetType() == typeof(TransformVariable))
+            {
+                target = (variable as TransformVariable).Value.position;
+            }
+            else if (variable.GetType() == typeof(GameObjectVariable))
+            {
+                target = (variable as GameObjectVariable).Value.transform.position;
+            }
+            else
+            {
+                return;
+            }
+
+            started = true;
+        }
+
+        void FixedUpdate()
+        {
+            if (started)
+            {
+                if (this.gameObject.transform.position != target)
+                {
+                    this.gameObject.transform.position = Vector3.MoveTowards(this.gameObject.transform.position, target, speed * Time.deltaTime);
+                }
+                else if (this.gameObject.transform.position == target)
+                {
+                    Continue();
+                }
+            }
+        }
+
+        public override string GetSummary()
+        {
+            return "Move towards target at speed of " + speed.ToString();
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/MoveToComplex.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/MoveToComplex.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 2b542307e4a5cf24f917d2c72d498d3b
+timeCreated: 1503276074
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/MoveVector3.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveVector3.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Fungus;
+
+[CommandInfo("Scripting", "MoveWithVector3", "Moves the current object for a specified amount of time with the specified Vector3 direction")]
+public class MoveVector3 : Command {
+
+    [SerializeField]
+    protected Vector3 Direction;
+
+    [SerializeField]
+    protected float Duration;
+
+    private bool Running = false;
+
+    private bool Infinite = false;
+
+    public override void OnEnter()
+    {
+        if (Direction == null)
+        {
+            return;
+        }
+
+        Running = true;
+
+        if (Duration == 0)
+        {
+            Infinite = true;
+        }
+    }
+
+    void FixedUpdate()
+    {
+        if (Running)
+        {
+            if (Infinite)
+            {
+                this.gameObject.transform.position += Direction * Time.deltaTime;
+                Continue();
+            }
+            else
+            {
+                if (Duration > 0)
+                {
+                    this.gameObject.transform.position += Direction * Time.deltaTime;
+                    Duration -= Time.deltaTime;
+                }
+                else
+                {
+                    Continue();
+                }
+            }
+        }
+    }
+
+    public override string GetSummary()
+    {
+        if (Direction == Vector3.zero)
+        {
+            return "Error: Command requires a direction for GameObject to travel";
+        }
+
+        return "Move current GameObject in direction of " + Direction + " for " + Duration + " seconds";
+    }
+
+}

--- a/Assets/Fungus/Scripts/Commands/MoveVector3.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/MoveVector3.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 1aba48a327628584e9687828f6d76915
+timeCreated: 1503276513
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/RandomVector3.cs
+++ b/Assets/Fungus/Scripts/Commands/RandomVector3.cs
@@ -1,0 +1,51 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Generates a random Vector3 between specified values to a Variable
+    /// </summary>
+    [CommandInfo("Scripting",
+                  "Get Random Vector3",
+                  "Sets a variable with a random vector 3")]
+
+    [AddComponentMenu("")]
+    public class RandomVector3 : Command
+    {
+        [Tooltip("The variable whos value will be set")]
+        [VariableProperty(typeof(Vector3Variable))]
+        [SerializeField]
+        protected Variable variable;
+
+        [SerializeField]
+        protected float minX;
+
+        [SerializeField]
+        protected float maxX;
+
+        [SerializeField]
+        protected float minY;
+
+        [SerializeField]
+        protected float maxY;
+
+        [SerializeField]
+        protected float minZ;
+
+        [SerializeField]
+        protected float maxZ;
+
+        public override void OnEnter()
+        {
+            Vector3Variable randomVector = (variable as Vector3Variable);
+
+            float xVal = UnityEngine.Random.Range(minX, maxX);
+            float yVal = UnityEngine.Random.Range(minY, maxY);
+            float zVal = UnityEngine.Random.Range(minZ, maxZ);
+
+            randomVector.Value = new Vector3(xVal, yVal, zVal);
+
+            Continue();
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/RandomVector3.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/RandomVector3.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 4f98c666220c59e47a3a3f122baed2ca
+timeCreated: 1503276724
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/ScaleObject.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleObject.cs
@@ -1,0 +1,99 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    public enum ScaleType
+    {
+        Increase,
+        Decrease
+    }
+    /// <summary>
+    /// Scales the current GameObject with magnitude for duration specified
+    /// </summary>
+    [CommandInfo("Scripting", "ScaleObject", "Scale Object with magnitude x for the duration specified.")]
+    public class ScaleObject : Command
+    {
+
+        [SerializeField]
+        protected ScaleType Scale;
+
+        [SerializeField]
+        protected float Magnitude;
+
+        [SerializeField]
+        protected float Duration;
+
+        private bool Running = false;
+        private bool Infinite = false;
+
+        public override void OnEnter()
+        {
+            if (Magnitude == 0)
+            {
+                return;
+            }
+
+            Running = true;
+
+            if (Duration == 0)
+            {
+                Infinite = true;
+            }
+        }
+
+        public override string GetSummary()
+        {
+            if (Magnitude == 0)
+            {
+                return "Error: No magnitude is selected.";
+            }
+
+            if (Duration == 0)
+            {
+                return "GameObject will scale at a magnitude of " + Magnitude + " infinitely.";
+            }
+            else
+            {
+                return "GameObject will scale at a magnitude of " + Magnitude + " for a duration of " + Duration + " seconds.";
+            }
+        }
+
+        void FixedUpdate()
+        {
+            if (Running)
+            {
+                if (Infinite)
+                {
+                    if (Scale == ScaleType.Increase)
+                    {
+                        this.gameObject.transform.localScale *= 1 + Magnitude * Time.deltaTime;
+                    }
+                    else
+                    {
+                        this.gameObject.transform.localScale /= 1 + Magnitude * Time.deltaTime;
+                    }
+                    Continue();
+                }
+                else
+                {
+                    if (Duration > 0)
+                    {
+                        if (Scale == ScaleType.Increase)
+                        {
+                            this.gameObject.transform.localScale *= 1 + Magnitude * Time.deltaTime;
+                        }
+                        else
+                        {
+                            this.gameObject.transform.localScale /= 1 + Magnitude * Time.deltaTime;
+                        }
+                        Duration -= Time.deltaTime;
+                    }
+                    else
+                    {
+                        Continue();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/ScaleObject.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/ScaleObject.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 4d72cc195c87ea64e8bf98c8044070ed
+timeCreated: 1503276811
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/SetTag.cs
+++ b/Assets/Fungus/Scripts/Commands/SetTag.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Sets the tag of the current GameObject
+    /// </summary>
+    [CommandInfo("Scripting",
+                  "Set Tag",
+                  "Set the tag of a game object. Be sure to add the tag to the Tags/Layers Manager")]
+
+    [AddComponentMenu("")]
+    public class SetTag : Command
+    {
+        public GameObject targetGameObject;
+
+        [Tooltip("Input text or a string variable")]
+        [SerializeField]
+        protected StringData newTagName;
+
+        [SerializeField]
+        protected bool self;
+
+        public override void OnEnter()
+        {
+            if (self == false)
+            {
+                targetGameObject.tag = newTagName;
+            }
+            if (self)
+            {
+                gameObject.tag = newTagName;
+            }
+
+            Continue();
+        }
+
+        public override string GetSummary()
+        {
+            if (newTagName == "")
+            {
+                return "Error: No Tag Name inputed";
+            }
+            if (self)
+            {
+                return "This GameObject";
+            }
+
+            return newTagName;
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/SetTag.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/SetTag.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: a6d941dff943baa44b84dda301a11b6a
+timeCreated: 1503276952
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/SpawnObjectTransform.cs
+++ b/Assets/Fungus/Scripts/Commands/SpawnObjectTransform.cs
@@ -1,0 +1,86 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Spawn GameObject using a Vector3, Transform or GameObject variable
+    /// </summary>
+    [CommandInfo("Scripting",
+                "Spawn Object With Object or Transform",
+                "Spawn a GameObject using a transform rather than a Vector 3")]
+    public class SpawnObjectTransform : Command
+    {
+        public GameObjectData SourceObject;
+
+        [VariableProperty(typeof(TransformVariable),
+                        typeof(GameObjectVariable))]
+        [SerializeField]
+        public Variable parentVariable;
+
+        [VariableProperty(typeof(TransformVariable),
+                        typeof(Vector3Variable),
+                        typeof(GameObjectVariable))]
+        [SerializeField]
+        public Variable spawnVariable;
+
+        [SerializeField]
+        public Vector3 SpawnRotation;
+
+        public override void OnEnter()
+        {
+            if (spawnVariable == null || SourceObject.Value == null)
+            {
+                return;
+            }
+
+            GameObject newObject = Instantiate(SourceObject.Value);
+
+            if (parentVariable != null)
+            {
+                if (parentVariable.GetType() == typeof(TransformVariable))
+                {
+                    newObject.transform.parent = (parentVariable as TransformVariable).Value;
+                }
+                else if (parentVariable.GetType() == typeof(GameObjectVariable))
+                {
+                    newObject.transform.parent = (parentVariable as GameObjectVariable).Value.transform;
+                }
+            }
+
+            if (spawnVariable.GetType() == typeof(TransformVariable))
+            {
+                newObject.transform.position = (spawnVariable as TransformVariable).Value.position;
+            }
+            else if (spawnVariable.GetType() == typeof(Vector3Variable))
+            {
+                newObject.transform.position = (spawnVariable as Vector3Variable).Value;
+            }
+            else
+            {
+                newObject.transform.position = (spawnVariable as GameObjectVariable).Value.transform.position;
+            }
+
+            Continue();
+        }
+
+        public override string GetSummary()
+        {
+            if (SourceObject.Value == null)
+            {
+                return "Error: No source GameObject specified";
+            }
+
+            if (spawnVariable == null)
+            {
+                return "Error: No spawn variable specfied";
+            }
+
+            return SourceObject.ToString();
+        }
+
+        public override Color GetButtonColor()
+        {
+            return new Color32(235, 191, 217, 255);
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/SpawnObjectTransform.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/SpawnObjectTransform.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 274530c02cefd5045ac52275bcc4e8c7
+timeCreated: 1503277013
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/Commands/Vector3Manipulation.cs
+++ b/Assets/Fungus/Scripts/Commands/Vector3Manipulation.cs
@@ -1,0 +1,147 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    public enum Operation
+    {
+        /// <summary> += operator. </summary>
+        Add,
+        /// <summary> -= operator. </summary>
+        Subtract,
+        /// <summary> *= operator. </summary>
+        Multiply,
+        /// <summary> /= operator. </summary>
+        Divide
+    }
+
+    public enum Vector3Attribute
+    {
+        X,
+        Y,
+        Z,
+        ALL
+    }
+
+    /// <summary>
+    /// Mathematical operations executed on Vector3
+    /// </summary>
+    [CommandInfo("Scripting", "Vector3 Manipulation", "Operations conducted on a Vector3 variable")]
+    public class Vector3Manipulation : Command
+    {
+
+        [SerializeField]
+        protected Vector3Data vector3var;
+
+        [SerializeField]
+        protected Operation operation;
+
+        [SerializeField]
+        protected Vector3Attribute property;
+
+        [SerializeField]
+        protected float changeValue;
+
+        public override void OnEnter()
+        {
+            if (vector3var.Value == null)
+            {
+                return;
+            }
+
+            Vector3 newValue = vector3var.Value;
+
+            switch (operation)
+            {
+                case Operation.Add:
+                    if (property == Vector3Attribute.X)
+                    {
+                        newValue.x += changeValue;
+                    }
+                    else if (property == Vector3Attribute.Y)
+                    {
+                        newValue.y += changeValue;
+                    }
+                    else if (property == Vector3Attribute.Z)
+                    {
+                        newValue.z += changeValue;
+                    }
+                    else
+                    {
+                        newValue += new Vector3(changeValue, changeValue, changeValue);
+                    }
+                    break;
+                case Operation.Subtract:
+                    if (property == Vector3Attribute.X)
+                    {
+                        newValue.x -= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Y)
+                    {
+                        newValue.y -= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Z)
+                    {
+                        newValue.z -= changeValue;
+                    }
+                    else
+                    {
+                        newValue -= new Vector3(changeValue, changeValue, changeValue);
+                    }
+                    break;
+                case Operation.Multiply:
+                    if (property == Vector3Attribute.X)
+                    {
+                        newValue.x *= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Y)
+                    {
+                        newValue.y *= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Z)
+                    {
+                        newValue.z *= changeValue;
+                    }
+                    else
+                    {
+                        newValue *= changeValue;
+                    }
+                    break;
+                case Operation.Divide:
+                    if (property == Vector3Attribute.X)
+                    {
+                        newValue.x /= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Y)
+                    {
+                        newValue.y /= changeValue;
+                    }
+                    else if (property == Vector3Attribute.Z)
+                    {
+                        newValue.z /= changeValue;
+                    }
+                    else
+                    {
+                        newValue /= changeValue;
+                    }
+                    break;
+            }
+            vector3var.Value = newValue;
+            Continue();
+        }
+
+        public override string GetSummary()
+        {
+            if (vector3var.Value == null)
+            {
+                return "Error: A Vector3 variable needs to be selected";
+            }
+
+            if (changeValue == 0)
+            {
+                return "Error: A change value needs to be specified";
+            }
+
+            return "Vector3 being " + operation.ToString() + " by the change value of " + changeValue;
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/Vector3Manipulation.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/Vector3Manipulation.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: 62780f431fae32540a0ad49bd6f98750
+timeCreated: 1503277254
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Fungus/Scripts/EventHandlers/CollisionEvent.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/CollisionEvent.cs
@@ -1,0 +1,60 @@
+﻿using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Event is triggered when the collision occurs between GameObject and specified tagged Object
+    /// </summary>
+    public enum CollisionType
+    {
+        Collision,
+        Trigger
+    }
+
+    [EventHandlerInfo("Scripting",
+                    "Collision Event",
+                    "Event is triggered when a collision event happens between the current GameObject and another GameObject")]
+    public class CollisionEvent : EventHandler
+    {
+        public CollisionType Type = CollisionType.Collision;
+        [Tooltip("Gametag of object to detect collisions with")]
+        public string Tag;
+
+        void OnCollisionEnter(Collision other)
+        {
+            if (Type == CollisionType.Collision)
+            {
+                if (Tag != "")
+                {
+                    if (other.gameObject.CompareTag(Tag))
+                    {
+                        ExecuteBlock();
+                    }
+                }
+                else
+                {
+                    ExecuteBlock();
+                }
+            }
+        }
+
+        void OnTriggerEnter(Collider other)
+        {
+            if (Type == CollisionType.Trigger)
+            {
+                if (Tag != "")
+                {
+                    if (other.gameObject.CompareTag(Tag))
+                    {
+                        ExecuteBlock();
+                    }
+                }
+                else
+                {
+                    ExecuteBlock();
+                }
+            }
+        }
+
+    }
+}

--- a/Assets/Fungus/Scripts/EventHandlers/CollisionEvent.cs.meta
+++ b/Assets/Fungus/Scripts/EventHandlers/CollisionEvent.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 82b809a530f14ff4f8f0856a029f72de
-timeCreated: 1503301037
+guid: e9d0177ab5d5eeb4ab39999d62b84e5d
+timeCreated: 1503277513
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/FungusExamples/MissileCommand.meta
+++ b/Assets/FungusExamples/MissileCommand.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d4c47c44984ac4046993753091884f43
+folderAsset: yes
+timeCreated: 1503300814
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/Prefabs.meta
+++ b/Assets/FungusExamples/MissileCommand/Prefabs.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1016e113bc2ec3f45902656d3c91b184
+folderAsset: yes
+timeCreated: 1503300822
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/Prefabs/CounterMissile.prefab
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/CounterMissile.prefab
@@ -1,0 +1,377 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1437464754457206}
+  m_IsPrefabParent: 1
+--- !u!1 &1437464754457206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4168910347714220}
+  - component: {fileID: 33222495660487308}
+  - component: {fileID: 135679741730196472}
+  - component: {fileID: 23951411149390750}
+  - component: {fileID: 54701475859573192}
+  - component: {fileID: 114249066764908130}
+  - component: {fileID: 114743800838938212}
+  - component: {fileID: 114399147448478066}
+  - component: {fileID: 114634009298056352}
+  - component: {fileID: 114067947351541018}
+  - component: {fileID: 114889957597418766}
+  - component: {fileID: 114967232637546380}
+  - component: {fileID: 114506686413842528}
+  - component: {fileID: 114005931233578884}
+  - component: {fileID: 114980445742961534}
+  - component: {fileID: 114228556143920214}
+  - component: {fileID: 114745669262667074}
+  - component: {fileID: 114854747274132302}
+  m_Layer: 0
+  m_Name: CounterMissile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4168910347714220
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.393431, y: 0.5256208, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23951411149390750
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33222495660487308
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &54701475859573192
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &114005931233578884
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea6e8f632db87477eb750446b28d73a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  commenterName: 
+  commentText: These Commands gets the cursor position and assigns it as the Target
+    variable. Moves to the object. Spawns an explosion object at its location and
+    destroys itself.
+--- !u!114 &114067947351541018
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 161a59e2b6558c744bc7d32dbd8210ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 2
+  indentLevel: 0
+  variable: {fileID: 0}
+  speed: 2
+--- !u!114 &114228556143920214
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b542307e4a5cf24f917d2c72d498d3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 8
+  indentLevel: 0
+  variable: {fileID: 114399147448478066}
+  speed: 3
+--- !u!114 &114249066764908130
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: 43.711655, y: 37.789608}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 244
+  zoom: 0.8497501
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 114743800838938212}
+  selectedCommands:
+  - {fileID: 114854747274132302}
+  variables:
+  - {fileID: 114399147448478066}
+  description: This flowchart contains the blocks that are for the counter missile.
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &114399147448478066
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d769ea3513ad47aabf805db5252341d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 1
+  key: CursorTarget
+  value: {x: 0, y: 0, z: 0}
+--- !u!114 &114506686413842528
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70d5016029a83424fae9a3ae74574504, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 5
+  indentLevel: 0
+  cursorPosition:
+    vector3Ref: {fileID: 114399147448478066}
+    vector3Val: {x: 0, y: 0, z: 0}
+--- !u!114 &114634009298056352
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff5d850a887844fe87ae7d366d3ab5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114743800838938212}
+--- !u!114 &114743800838938212
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 92
+    y: 130
+    width: 120
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 0
+  blockName: Create
+  description: This block is triggered when the GameObject is created in the scene.
+  eventHandler: {fileID: 114634009298056352}
+  commandList:
+  - {fileID: 114005931233578884}
+  - {fileID: 114980445742961534}
+  - {fileID: 114228556143920214}
+  - {fileID: 114854747274132302}
+  - {fileID: 114745669262667074}
+--- !u!114 &114745669262667074
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 9
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114854747274132302
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 274530c02cefd5045ac52275bcc4e8c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 10
+  indentLevel: 0
+  SourceObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1345717159619546, guid: fb204fcc9ea9b0b419b8d39f8577b07b,
+      type: 2}
+  parentVariable: {fileID: 0}
+  spawnVariable: {fileID: 114399147448478066}
+  SpawnRotation: {x: 0, y: 0, z: 0}
+--- !u!114 &114889957597418766
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df406b89e7885984e84eb6d513ced18e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 3
+  indentLevel: 0
+  SourceObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1345717159619546, guid: fb204fcc9ea9b0b419b8d39f8577b07b,
+      type: 2}
+  parentVariable: {fileID: 0}
+  spawnVariable: {fileID: 114399147448478066}
+  SpawnRotation: {x: 0, y: 0, z: 0}
+--- !u!114 &114967232637546380
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 4
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 0}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114980445742961534
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6ccf34d01870418adea815e86dfcf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 7
+  indentLevel: 0
+  cursorPosition:
+    vector3Ref: {fileID: 114399147448478066}
+    vector3Val: {x: 0, y: 0, z: 0}
+--- !u!135 &135679741730196472
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1437464754457206}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/FungusExamples/MissileCommand/Prefabs/CounterMissile.prefab.meta
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/CounterMissile.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9317eceb7646a5f4c95e6b053d6c4e12
+timeCreated: 1499056126
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Explosion.prefab
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Explosion.prefab
@@ -1,0 +1,299 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1345717159619546}
+  m_IsPrefabParent: 1
+--- !u!1 &1345717159619546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4486773407143418}
+  - component: {fileID: 33736193633768264}
+  - component: {fileID: 135753627222324550}
+  - component: {fileID: 23691746616562604}
+  - component: {fileID: 114545091276409378}
+  - component: {fileID: 114761188470299124}
+  - component: {fileID: 114210017145298410}
+  - component: {fileID: 114233345258631580}
+  - component: {fileID: 114679850713877730}
+  - component: {fileID: 54726003571745742}
+  - component: {fileID: 114493735136259048}
+  - component: {fileID: 114790514889479400}
+  - component: {fileID: 114589572405444254}
+  - component: {fileID: 114188090210663372}
+  m_Layer: 0
+  m_Name: Explosion
+  m_TagString: Explosion
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4486773407143418
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6, y: -0.446, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23691746616562604
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: d1ea9c354834d0743847b44afdc026f0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33736193633768264
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &54726003571745742
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &114188090210663372
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 11
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114210017145298410
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff5d850a887844fe87ae7d366d3ab5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114761188470299124}
+--- !u!114 &114233345258631580
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114493735136259048
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c378b88deb9289469a6ece6a27df1c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 8
+  indentLevel: 0
+  Scale: 0
+  Magnitude: 1.1
+  Duration: 1.5
+--- !u!114 &114545091276409378
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0
+  scrollPos: {x: 19.550943, y: 26.014084}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 228
+  zoom: 0.92524993
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 114761188470299124}
+  selectedCommands:
+  - {fileID: 114188090210663372}
+  variables: []
+  description: This flowchart contains the blocks for the explosion gameobject.
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &114589572405444254
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d72cc195c87ea64e8bf98c8044070ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 10
+  indentLevel: 0
+  Scale: 0
+  Magnitude: 1.1
+  Duration: 1
+--- !u!114 &114679850713877730
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3315ad2ebb85443909a1203d56d9344e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 7
+  indentLevel: 0
+  _duration:
+    floatRef: {fileID: 0}
+    floatVal: 1
+  durationOLD: 0
+--- !u!114 &114761188470299124
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 105
+    y: 130
+    width: 120
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 0
+  blockName: Start
+  description: This block is triggered on the creation of this GameObject in the scene.
+  eventHandler: {fileID: 114210017145298410}
+  commandList:
+  - {fileID: 114790514889479400}
+  - {fileID: 114589572405444254}
+  - {fileID: 114679850713877730}
+  - {fileID: 114188090210663372}
+--- !u!114 &114790514889479400
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea6e8f632db87477eb750446b28d73a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 9
+  indentLevel: 0
+  commenterName: 
+  commentText: Increase the object's scale for 2 seconds, wait for 2 seconds and destroy
+    this game object.
+--- !u!135 &135753627222324550
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1345717159619546}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Explosion.prefab.meta
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Explosion.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fb204fcc9ea9b0b419b8d39f8577b07b
+timeCreated: 1499056483
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Missile.prefab
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Missile.prefab
@@ -1,0 +1,487 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1507970119297392}
+  m_IsPrefabParent: 1
+--- !u!1 &1507970119297392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4653283104136682}
+  - component: {fileID: 33395733265420106}
+  - component: {fileID: 135453096846006378}
+  - component: {fileID: 23660296811467082}
+  - component: {fileID: 54754229408994542}
+  - component: {fileID: 114849034883679474}
+  - component: {fileID: 114759492936725572}
+  - component: {fileID: 114278077670822478}
+  - component: {fileID: 114331682078974962}
+  - component: {fileID: 114534178854885718}
+  - component: {fileID: 114547181349363454}
+  - component: {fileID: 114991070647556532}
+  - component: {fileID: 114508127851286540}
+  - component: {fileID: 114539638551773334}
+  - component: {fileID: 114066149773571862}
+  - component: {fileID: 114980852002437210}
+  - component: {fileID: 114275965029560390}
+  - component: {fileID: 114447196383061024}
+  - component: {fileID: 114098723124473652}
+  - component: {fileID: 114865903383804792}
+  - component: {fileID: 114815933431242810}
+  - component: {fileID: 114235475881563630}
+  - component: {fileID: 114848371541831230}
+  - component: {fileID: 114978575832384904}
+  m_Layer: 0
+  m_Name: Missile
+  m_TagString: Missile
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4653283104136682
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23660296811467082
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33395733265420106
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &54754229408994542
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &114066149773571862
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: -542.84717
+    y: 196.68832
+    width: 178
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 6
+  blockName: Collision With Explosio
+  description: This event is triggered when a collision with an explosion happens.
+  eventHandler: {fileID: 114815933431242810}
+  commandList:
+  - {fileID: 114235475881563630}
+--- !u!114 &114098723124473652
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9d0177ab5d5eeb4ab39999d62b84e5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114991070647556532}
+  Type: 1
+  Tag: Turret
+--- !u!114 &114235475881563630
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 10
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114275965029560390
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 7
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 0}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114278077670822478
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff5d850a887844fe87ae7d366d3ab5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114759492936725572}
+--- !u!114 &114331682078974962
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 161a59e2b6558c744bc7d32dbd8210ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 2
+  indentLevel: 0
+  variable: {fileID: 114547181349363454}
+  speed: 1
+--- !u!114 &114447196383061024
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea6e8f632db87477eb750446b28d73a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 8
+  indentLevel: 0
+  commenterName: 
+  commentText: Find a turret gameobject and move towards it.
+--- !u!114 &114508127851286540
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee2032128a8c177489dbeaa09f3df88a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114991070647556532}
+  Type: 1
+  Tag: Turret
+--- !u!114 &114534178854885718
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03e31dafe3f9b054389486b5afa08992, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 3
+  indentLevel: 0
+  targetGameObject: {fileID: 114547181349363454}
+  objectTagName:
+    stringRef: {fileID: 0}
+    stringVal: Turret
+--- !u!114 &114539638551773334
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 5
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 114991070647556532}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114547181349363454
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1941e052c0ed4280b25507cd2e6ad8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 0
+  key: Target
+  value: {fileID: 0}
+--- !u!114 &114759492936725572
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: -695.8356
+    y: 101.3934
+    width: 120
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 0
+  blockName: On Create
+  description: This block is triggered when the gameobject is created in the scene.
+  eventHandler: {fileID: 114278077670822478}
+  commandList:
+  - {fileID: 114447196383061024}
+  - {fileID: 114848371541831230}
+  - {fileID: 114978575832384904}
+--- !u!114 &114815933431242810
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9d0177ab5d5eeb4ab39999d62b84e5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114066149773571862}
+  Type: 1
+  Tag: Explosion
+--- !u!114 &114848371541831230
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d08722ab82537ee4ab3b45e527b9924d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 11
+  indentLevel: 0
+  targetGameObject: {fileID: 114547181349363454}
+  objectTagName:
+    stringRef: {fileID: 0}
+    stringVal: Turret
+--- !u!114 &114849034883679474
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 0
+  scrollPos: {x: 742.84735, y: 34.311775}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 246
+  zoom: 0.9999995
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 114991070647556532}
+  selectedCommands: []
+  variables:
+  - {fileID: 114547181349363454}
+  description: This flowchart controls the actions and blocks that cause action for
+    the Missile.
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &114865903383804792
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 9
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &114978575832384904
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b542307e4a5cf24f917d2c72d498d3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 12
+  indentLevel: 0
+  variable: {fileID: 114547181349363454}
+  speed: 2
+--- !u!114 &114980852002437210
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee2032128a8c177489dbeaa09f3df88a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 114066149773571862}
+  Type: 1
+  Tag: Explosion
+--- !u!114 &114991070647556532
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: -537.8472
+    y: 64.6883
+    width: 166
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 4
+  blockName: Collision With Turret
+  description: This event is triggered when a collision with an turret happens.
+  eventHandler: {fileID: 114098723124473652}
+  commandList:
+  - {fileID: 114865903383804792}
+--- !u!135 &135453096846006378
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1507970119297392}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Missile.prefab.meta
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Missile.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 340e9f025aea558478f4a941bd802e03
+timeCreated: 1498978368
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Yello.mat
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Yello.mat
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Yello
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.88468564, g: 0.89705884, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/FungusExamples/MissileCommand/Prefabs/Yello.mat.meta
+++ b/Assets/FungusExamples/MissileCommand/Prefabs/Yello.mat.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d1ea9c354834d0743847b44afdc026f0
+timeCreated: 1499056459
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/MissileCommand/SampleScene.unity
+++ b/Assets/FungusExamples/MissileCommand/SampleScene.unity
@@ -1,0 +1,1548 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 8
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 3
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_ShadowMaskMode: 2
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &50435023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 50435027}
+  - component: {fileID: 50435026}
+  - component: {fileID: 50435025}
+  - component: {fileID: 50435024}
+  - component: {fileID: 50435028}
+  - component: {fileID: 50435032}
+  - component: {fileID: 50435039}
+  - component: {fileID: 50435038}
+  - component: {fileID: 50435037}
+  - component: {fileID: 50435029}
+  - component: {fileID: 50435030}
+  m_Layer: 0
+  m_Name: Turret
+  m_TagString: Turret
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &50435024
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &50435025
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &50435026
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &50435027
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7, y: -4.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &50435028
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &50435029
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9d0177ab5d5eeb4ab39999d62b84e5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 50435039}
+  Type: 1
+  Tag: Missile
+--- !u!114 &50435030
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &50435032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: -30, y: 16}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 243
+  zoom: 1
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 50435039}
+  selectedCommands:
+  - {fileID: 50435030}
+  variables: []
+  description: 
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &50435037
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee2032128a8c177489dbeaa09f3df88a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &50435038
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 50435039}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &50435039
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 50435023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 158.5
+    y: 170
+    width: 168
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 5
+  blockName: Collision With Missile
+  description: This block is triggered when collision happens with a Missile Object.
+  eventHandler: {fileID: 50435029}
+  commandList:
+  - {fileID: 50435030}
+--- !u!1 &422935887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 422935891}
+  - component: {fileID: 422935890}
+  - component: {fileID: 422935889}
+  - component: {fileID: 422935888}
+  - component: {fileID: 422935892}
+  - component: {fileID: 422935896}
+  - component: {fileID: 422935902}
+  - component: {fileID: 422935901}
+  - component: {fileID: 422935903}
+  - component: {fileID: 422935894}
+  - component: {fileID: 422935893}
+  m_Layer: 0
+  m_Name: Turret (1)
+  m_TagString: Turret
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &422935888
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &422935889
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &422935890
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &422935891
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -4.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &422935892
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &422935893
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &422935894
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9d0177ab5d5eeb4ab39999d62b84e5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 422935902}
+  Type: 1
+  Tag: Missile
+--- !u!114 &422935896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: -1, y: -1}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 243
+  zoom: 1
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 422935902}
+  selectedCommands: []
+  variables: []
+  description: 
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &422935901
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee2032128a8c177489dbeaa09f3df88a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &422935902
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 152
+    y: 171
+    width: 168
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 5
+  blockName: Collision With Missile
+  description: This block is triggered when collision happens with a Missile Object.
+  eventHandler: {fileID: 422935894}
+  commandList:
+  - {fileID: 422935893}
+--- !u!114 &422935903
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 422935887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 422935902}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!1 &800924179
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 800924181}
+  - component: {fileID: 800924180}
+  m_Layer: 0
+  m_Name: _FungusState
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &800924180
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 800924179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61dddfdc5e0e44ca298d8f46f7f5a915, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  selectedFlowchart: {fileID: 50435032}
+--- !u!4 &800924181
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 800924179}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &851753114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 851753118}
+  - component: {fileID: 851753117}
+  - component: {fileID: 851753116}
+  - component: {fileID: 851753115}
+  - component: {fileID: 851753119}
+  - component: {fileID: 851753123}
+  - component: {fileID: 851753130}
+  - component: {fileID: 851753129}
+  - component: {fileID: 851753128}
+  - component: {fileID: 851753121}
+  - component: {fileID: 851753120}
+  m_Layer: 0
+  m_Name: Turret (2)
+  m_TagString: Turret
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &851753115
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &851753116
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &851753117
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &851753118
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7, y: -4.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &851753119
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &851753120
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82b809a530f14ff4f8f0856a029f72de, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 0
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  self: 1
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &851753121
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9d0177ab5d5eeb4ab39999d62b84e5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 851753130}
+  Type: 1
+  Tag: Missile
+--- !u!114 &851753123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: 0, y: 0}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 243
+  zoom: 1
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 851753130}
+  selectedCommands: []
+  variables: []
+  description: 
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &851753128
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee2032128a8c177489dbeaa09f3df88a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &851753129
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81be3d7e84da460788dccea95a3313a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 8
+  indentLevel: 0
+  errorMessage: 
+  <CommandIndex>k__BackingField: 0
+  <IsExecuting>k__BackingField: 0
+  <ExecutingIconTimer>k__BackingField: 0
+  <ParentBlock>k__BackingField: {fileID: 851753130}
+  _targetGameObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 0}
+  targetGameObjectOLD: {fileID: 0}
+--- !u!114 &851753130
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 851753114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 154.5
+    y: 191
+    width: 168
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 5
+  blockName: Collision With Missile
+  description: This block is triggered when collision happens with a Missile Object.
+  eventHandler: {fileID: 851753121}
+  commandList:
+  - {fileID: 851753120}
+--- !u!115 &885776548
+MonoScript:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 4
+  m_Script: 
+  m_DefaultReferences: {}
+  m_Icon: {fileID: 0}
+  m_ExecutionOrder: 0
+  m_ClassName: GetClosestGameObject
+  m_Namespace: Fungus
+  m_AssemblyName: Assembly-CSharp
+  m_IsEditorScript: 0
+--- !u!1 &1041410308
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1041410312}
+  - component: {fileID: 1041410311}
+  - component: {fileID: 1041410310}
+  - component: {fileID: 1041410309}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1041410309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1041410308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1997211142, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ForceModuleActive: 0
+--- !u!114 &1041410310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1041410308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1041410311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1041410308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!4 &1041410312
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1041410308}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1099103095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1099103106}
+  - component: {fileID: 1099103105}
+  - component: {fileID: 1099103111}
+  - component: {fileID: 1099103110}
+  - component: {fileID: 1099103107}
+  - component: {fileID: 1099103113}
+  - component: {fileID: 1099103108}
+  - component: {fileID: 1099103112}
+  - component: {fileID: 1099103096}
+  - component: {fileID: 1099103098}
+  - component: {fileID: 1099103099}
+  - component: {fileID: 1099103097}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1099103096
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea6e8f632db87477eb750446b28d73a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 18
+  indentLevel: 0
+  commenterName: 
+  commentText: Finds a Turret GameObject and creates a counter missile at that location.
+--- !u!114 &1099103097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 274530c02cefd5045ac52275bcc4e8c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 22
+  indentLevel: 0
+  SourceObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1437464754457206, guid: 9317eceb7646a5f4c95e6b053d6c4e12,
+      type: 2}
+  parentVariable: {fileID: 0}
+  spawnVariable: {fileID: 1099103107}
+  SpawnRotation: {x: 0, y: 0, z: 0}
+--- !u!114 &1099103098
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ece6ccf34d01870418adea815e86dfcf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 20
+  indentLevel: 0
+  cursorPosition:
+    vector3Ref: {fileID: 1099103113}
+    vector3Val: {x: 0, y: 0, z: 0}
+--- !u!114 &1099103099
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 885776548}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 21
+  indentLevel: 0
+  location:
+    vector3Ref: {fileID: 1099103113}
+    vector3Val: {x: 0, y: 0, z: 0}
+  targetGameObject:
+    gameObjectRef: {fileID: 1099103107}
+    gameObjectVal: {fileID: 0}
+  Tag: Turret
+  maxRange: 40
+--- !u!114 &1099103105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: -37.343727, y: 26.174023}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 237
+  zoom: 0.87100124
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 1099103111}
+  selectedCommands:
+  - {fileID: 1099103097}
+  variables:
+  - {fileID: 1099103107}
+  - {fileID: 1099103113}
+  description: 
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!4 &1099103106
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.9629631, y: 2.222222, z: -9.700012}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1099103107
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1941e052c0ed4280b25507cd2e6ad8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 0
+  key: Turret
+  value: {fileID: 0}
+--- !u!114 &1099103108
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03e31dafe3f9b054389486b5afa08992, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1099103110
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 000864f8e9e1748a39807861d0e60e29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 1099103111}
+  keyPressType: 0
+  keyCode: 323
+--- !u!114 &1099103111
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 171.17316
+    y: 190.80293
+    width: 120
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 6
+  blockName: MouseClick
+  description: Triggered on the mouse click.
+  eventHandler: {fileID: 1099103110}
+  commandList:
+  - {fileID: 1099103096}
+  - {fileID: 1099103098}
+  - {fileID: 1099103099}
+  - {fileID: 1099103097}
+--- !u!114 &1099103112
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df406b89e7885984e84eb6d513ced18e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1099103113
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099103095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d769ea3513ad47aabf805db5252341d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 1
+  key: MousePosition
+  value: {x: 1, y: 1, z: 1}
+--- !u!1 &1739203224
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1739203229}
+  - component: {fileID: 1739203228}
+  - component: {fileID: 1739203227}
+  - component: {fileID: 1739203226}
+  - component: {fileID: 1739203225}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1739203225
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739203224}
+  m_Enabled: 1
+--- !u!124 &1739203226
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739203224}
+  m_Enabled: 1
+--- !u!92 &1739203227
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739203224}
+  m_Enabled: 1
+--- !u!20 &1739203228
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739203224}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &1739203229
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739203224}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1957208698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1957208699}
+  - component: {fileID: 1957208700}
+  - component: {fileID: 1957208708}
+  - component: {fileID: 1957208707}
+  - component: {fileID: 1957208706}
+  - component: {fileID: 1957208705}
+  - component: {fileID: 1957208704}
+  - component: {fileID: 1957208703}
+  - component: {fileID: 1957208702}
+  - component: {fileID: 1957208701}
+  - component: {fileID: 1957208710}
+  - component: {fileID: 1957208709}
+  - component: {fileID: 1957208712}
+  - component: {fileID: 1957208711}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Spawn
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1957208699
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 4.79, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1957208700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a334fe2ffb574b3583ff3b18b4792d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  scrollPos: {x: 0, y: 0}
+  variablesScrollPos: {x: 0, y: 0}
+  variablesExpanded: 1
+  blockViewHeight: 253
+  zoom: 1
+  scrollViewRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0
+    height: 0
+  selectedBlocks:
+  - {fileID: 1957208707}
+  selectedCommands:
+  - {fileID: 1957208711}
+  variables:
+  - {fileID: 1957208708}
+  - {fileID: 1957208702}
+  description: This is the flowchart for the Spawn Object Variable, this object will
+    gameobject will create a missile prefab every 2 seconds while the game is running.
+  stepPause: 0
+  colorCommands: 1
+  hideComponents: 1
+  saveSelection: 1
+  localizationId: 
+  showLineNumbers: 0
+  hideCommands: []
+  luaEnvironment: {fileID: 0}
+  luaBindingName: flowchart
+--- !u!114 &1957208701
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2edb956a3500b84fac8a74450e51804, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1957208702
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d769ea3513ad47aabf805db5252341d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 0
+  key: CurrentPosition
+  value: {x: 0, y: 0, z: 0}
+--- !u!114 &1957208703
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93cb9773f2ca04e2bbf7a68ccfc23267, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 3
+  indentLevel: 0
+--- !u!114 &1957208704
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df406b89e7885984e84eb6d513ced18e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1957208705
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 663c8a7831a104d16ad7078a4dc2bd10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 1
+  indentLevel: 0
+  compareOperator: 0
+  variable: {fileID: 1957208708}
+  booleanData:
+    booleanRef: {fileID: 0}
+    booleanVal: 1
+  integerData:
+    integerRef: {fileID: 0}
+    integerVal: 0
+  floatData:
+    floatRef: {fileID: 0}
+    floatVal: 0
+  stringData:
+    stringRef: {fileID: 0}
+    stringVal: 
+--- !u!114 &1957208706
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff5d850a887844fe87ae7d366d3ab5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentBlock: {fileID: 1957208707}
+--- !u!114 &1957208707
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d73aef2cfc4f51abf34ac00241f60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeRect:
+    serializedVersion: 2
+    x: 141
+    y: 146
+    width: 120
+    height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
+  itemId: 0
+  blockName: Spawner
+  description: This Block is triggered when this GameObject is loaded into the scene.
+  eventHandler: {fileID: 1957208706}
+  commandList:
+  - {fileID: 1957208705}
+  - {fileID: 1957208709}
+  - {fileID: 1957208711}
+  - {fileID: 1957208712}
+  - {fileID: 1957208710}
+  - {fileID: 1957208703}
+--- !u!114 &1957208708
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d02d9822eec54c98afe95bb497211b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scope: 0
+  key: GameRunning
+  value: 1
+--- !u!114 &1957208709
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea6e8f632db87477eb750446b28d73a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 6
+  indentLevel: 1
+  commenterName: 
+  commentText: Retrieve the current location of the spawner, spawn the object and
+    wait 2 seconds.
+--- !u!114 &1957208710
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3315ad2ebb85443909a1203d56d9344e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 5
+  indentLevel: 1
+  _duration:
+    floatRef: {fileID: 0}
+    floatVal: 2
+  durationOLD: 0
+--- !u!114 &1957208711
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d81bc03424c92d54d9a2e2b817044021, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 8
+  indentLevel: 1
+  currentPosition: {fileID: 1957208702}
+--- !u!114 &1957208712
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957208698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 274530c02cefd5045ac52275bcc4e8c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 7
+  indentLevel: 1
+  SourceObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1507970119297392, guid: 340e9f025aea558478f4a941bd802e03,
+      type: 2}
+  parentVariable: {fileID: 0}
+  spawnVariable: {fileID: 1957208702}
+  SpawnRotation: {x: 0, y: 0, z: 0}

--- a/Assets/FungusExamples/MissileCommand/SampleScene.unity.meta
+++ b/Assets/FungusExamples/MissileCommand/SampleScene.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 920bc9202a767c44ba88f7224a52c7e7
+timeCreated: 1503300827
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This change includes some commands and events which I have written that may come in handy when creating a game with mechanics similar to Missile Command.

**Commands**
- Find GameObject using Tag
- Get the closest GameObject using Tag
- Get current position of GameObject
- Get cursor position of GameObject
- MoveTo command specifying speed
- MoveTo command specifying Vector3 direction
- Generating a random Vector3
- Scale GameObject
- Set Tag
- Spawn Object using Transform
- Vector3 Operations

**Events**
- Collision Event
