### PR TITLE
SceneManager Delegate handling moved

### DIFF
--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -87,14 +87,6 @@ namespace Fungus
         protected StringSubstituter stringSubstituer;
 
         #if UNITY_5_4_OR_NEWER
-        protected virtual void Awake()
-        {
-            CheckEventSystem();
-
-            UnityEngine.SceneManagement.SceneManager.activeSceneChanged += (A, B) => {
-                LevelWasLoaded();
-            };
-        }
         #else
         protected virtual void OnLevelWasLoaded(int level) 
         {
@@ -137,11 +129,20 @@ namespace Fungus
             eventSystemPresent = true;
         }
 
+        private void SceneManager_activeSceneChanged(UnityEngine.SceneManagement.Scene arg0, UnityEngine.SceneManagement.Scene arg1)
+        {
+            LevelWasLoaded();
+        }
+
         protected virtual void OnEnable()
         {
             if (!cachedFlowcharts.Contains(this))
             {
                 cachedFlowcharts.Add(this);
+                //TODO these pairs could be replaced by something static that manages all active flowcharts
+                #if UNITY_5_4_OR_NEWER
+                UnityEngine.SceneManagement.SceneManager.activeSceneChanged += SceneManager_activeSceneChanged;
+                #endif
             }
 
             CheckItemIds();
@@ -154,6 +155,10 @@ namespace Fungus
         protected virtual void OnDisable()
         {
             cachedFlowcharts.Remove(this);
+
+            #if UNITY_5_4_OR_NEWER
+            UnityEngine.SceneManagement.SceneManager.activeSceneChanged -= SceneManager_activeSceneChanged;
+            #endif
 
             StringSubstituter.UnregisterHandler(this);   
         }

--- a/Assets/Fungus/Scripts/Components/Localization.cs
+++ b/Assets/Fungus/Scripts/Components/Localization.cs
@@ -42,12 +42,6 @@ namespace Fungus
         protected static Dictionary<string, string> localizedStrings = new Dictionary<string, string>();
 
         #if UNITY_5_4_OR_NEWER
-        protected virtual void Awake()
-        {
-            UnityEngine.SceneManagement.SceneManager.activeSceneChanged += (A, B) => {
-                LevelWasLoaded();
-            };
-        }
         #else
         public virtual void OnLevelWasLoaded(int level) 
         {
@@ -65,14 +59,25 @@ namespace Fungus
             }
         }
 
+        private void SceneManager_activeSceneChanged(UnityEngine.SceneManagement.Scene arg0, UnityEngine.SceneManagement.Scene arg1)
+        {
+            LevelWasLoaded();
+        }
+
         protected virtual void OnEnable()
         {
             StringSubstituter.RegisterHandler(this);
+            #if UNITY_5_4_OR_NEWER
+            UnityEngine.SceneManagement.SceneManager.activeSceneChanged += SceneManager_activeSceneChanged;
+            #endif
         }
 
         protected virtual void OnDisable()
         {
             StringSubstituter.UnregisterHandler(this);
+            #if UNITY_5_4_OR_NEWER
+            UnityEngine.SceneManagement.SceneManager.activeSceneChanged -= SceneManager_activeSceneChanged;
+            #endif
         }
 
         protected virtual void Start()


### PR DESCRIPTION
Part of #638. May have been causing flowcharts and their referenced objects to be ineligible for GC at run-time and in editor.

Flowchart now registers and unregisters from SceneManager in OnEnable and OnDisable respectively
Localization now registers and unregisters from SceneManager in OnEnable and OnDisable respectively