### PR TITLE
Added ability to show variable list in the Flowchart Inspector

### DIFF
--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -80,9 +80,6 @@ namespace Fungus
         [Tooltip("The ExecuteLua command adds a global Lua variable with this name bound to the flowchart prior to executing.")]
         [SerializeField] protected string luaBindingName = "flowchart";
 
-        [Tooltip("Draw the variable gui in the inspector.")]
-        [SerializeField] protected bool showVariables = true;
-
         protected static List<Flowchart> cachedFlowcharts = new List<Flowchart>();
 
         protected static bool eventSystemPresent;

--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -81,7 +81,7 @@ namespace Fungus
         [SerializeField] protected string luaBindingName = "flowchart";
 
         [Tooltip("Draw the variable gui in the inspector.")]
-        [SerializeField] protected bool showVariablesInInspector = true;
+        [SerializeField] protected bool showVariables = true;
 
         protected static List<Flowchart> cachedFlowcharts = new List<Flowchart>();
 

--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -80,6 +80,9 @@ namespace Fungus
         [Tooltip("The ExecuteLua command adds a global Lua variable with this name bound to the flowchart prior to executing.")]
         [SerializeField] protected string luaBindingName = "flowchart";
 
+        [Tooltip("Draw the variable gui in the inspector.")]
+        [SerializeField] protected bool showVariablesInInspector = true;
+
         protected static List<Flowchart> cachedFlowcharts = new List<Flowchart>();
 
         protected static bool eventSystemPresent;

--- a/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
@@ -91,7 +91,7 @@ namespace Fungus.EditorUtils
             //Show the variables in the flowchart inspector
             GUILayout.Space(20);
 
-            DrawVariablesGUI(false, Screen.width - 70);
+            DrawVariablesGUI(false, Mathf.FloorToInt(EditorGUIUtility.currentViewWidth) - VariableListAdaptor.ReorderListSkirts);
 
         }
 
@@ -165,8 +165,10 @@ namespace Fungus.EditorUtils
                 Rect lastRect = buttonRect;
                 lastRect.x += 5;
                 lastRect.y += 5;
+                
                 //this is not required, seems to be legacy that is hidden in the normal reorderable
-                //EditorGUI.Foldout(lastRect, true, "");
+                if(showVariableToggleButton)
+                    EditorGUI.Foldout(lastRect, true, "");
 
                 Rect plusRect = listRect;
                 plusRect.x += plusRect.width - plusWidth;

--- a/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
@@ -50,7 +50,7 @@ namespace Fungus.EditorUtils
             hideCommandsProp = serializedObject.FindProperty("hideCommands");
             luaEnvironmentProp = serializedObject.FindProperty("luaEnvironment");
             luaBindingNameProp = serializedObject.FindProperty("luaBindingName");
-            varInspectorProp = serializedObject.FindProperty("showVariablesInInspector"); 
+            varInspectorProp = serializedObject.FindProperty("showVariables"); 
 
             addTexture = FungusEditorResources.AddSmall;
         }
@@ -72,11 +72,7 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(showLineNumbersProp);
             EditorGUILayout.PropertyField(luaEnvironmentProp);
             EditorGUILayout.PropertyField(luaBindingNameProp);
-
-            if (!FungusEditorPreferences.hideVariableInFlowchartInspector)
-            {
-                EditorGUILayout.PropertyField(varInspectorProp);
-            }
+            EditorGUILayout.PropertyField(varInspectorProp);
 
             // Show list of commands to hide in Add Command menu
             ReorderableListGUI.Title(new GUIContent(hideCommandsProp.displayName, hideCommandsProp.tooltip));
@@ -95,7 +91,7 @@ namespace Fungus.EditorUtils
 
             serializedObject.ApplyModifiedProperties();
 
-            if (varInspectorProp.boolValue && !FungusEditorPreferences.hideVariableInFlowchartInspector)
+            if (varInspectorProp.boolValue)
             {
                 GUILayout.Space(20);
 

--- a/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
@@ -30,7 +30,6 @@ namespace Fungus.EditorUtils
         protected SerializedProperty hideCommandsProp;
         protected SerializedProperty luaEnvironmentProp;
         protected SerializedProperty luaBindingNameProp;
-        protected SerializedProperty varInspectorProp;
 
         protected Texture2D addTexture;
                 
@@ -50,7 +49,6 @@ namespace Fungus.EditorUtils
             hideCommandsProp = serializedObject.FindProperty("hideCommands");
             luaEnvironmentProp = serializedObject.FindProperty("luaEnvironment");
             luaBindingNameProp = serializedObject.FindProperty("luaBindingName");
-            varInspectorProp = serializedObject.FindProperty("showVariables"); 
 
             addTexture = FungusEditorResources.AddSmall;
         }
@@ -72,7 +70,6 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(showLineNumbersProp);
             EditorGUILayout.PropertyField(luaEnvironmentProp);
             EditorGUILayout.PropertyField(luaBindingNameProp);
-            EditorGUILayout.PropertyField(varInspectorProp);
 
             // Show list of commands to hide in Add Command menu
             ReorderableListGUI.Title(new GUIContent(hideCommandsProp.displayName, hideCommandsProp.tooltip));
@@ -91,15 +88,13 @@ namespace Fungus.EditorUtils
 
             serializedObject.ApplyModifiedProperties();
 
-            if (varInspectorProp.boolValue)
-            {
-                GUILayout.Space(20);
+            //Show the variables in the flowchart inspector
+            GUILayout.Space(20);
 
-                DrawVariablesGUI(false, Screen.width - 70);
-            }
+            DrawVariablesGUI(false, Screen.width - 70);
 
         }
-        
+
         public virtual void DrawVariablesGUI(bool showVariableToggleButton, int w)
         {
             serializedObject.Update();
@@ -109,6 +104,7 @@ namespace Fungus.EditorUtils
             if (t.Variables.Count == 0)
             {
                 t.VariablesExpanded = true;
+                //showVariableToggleButton = true;
             }
 
             if (showVariableToggleButton && !t.VariablesExpanded)
@@ -127,35 +123,26 @@ namespace Fungus.EditorUtils
             else
             {
                 Rect listRect = new Rect();
-
-                if (t.Variables.Count > 0)
+                
+                // Remove any null variables from the list
+                // Can sometimes happen when upgrading to a new version of Fungus (if .meta GUID changes for a variable class)
+                for (int i = t.Variables.Count - 1; i >= 0; i--)
                 {
-                    // Remove any null variables from the list
-                    // Can sometimes happen when upgrading to a new version of Fungus (if .meta GUID changes for a variable class)
-                    for (int i = t.Variables.Count - 1; i >= 0; i--)
+                    if (t.Variables[i] == null)
                     {
-                        if (t.Variables[i] == null)
-                        {
-                            t.Variables.RemoveAt(i);
-                        }
+                        t.Variables.RemoveAt(i);
                     }
-
-                    ReorderableListGUI.Title("Variables");
-                    VariableListAdaptor adaptor = new VariableListAdaptor(variablesProp, 0, w == 0 ? VariableListAdaptor.DefaultWidth : w);
-
-                    ReorderableListFlags flags = ReorderableListFlags.DisableContextMenu | ReorderableListFlags.HideAddButton;
-
-                    ReorderableListControl.DrawControlFromState(adaptor, null, flags);
-
-                    listRect = GUILayoutUtility.GetLastRect();
-                }
-                else
-                {
-                    GUILayoutUtility.GetRect(300, 24);
-                    listRect = GUILayoutUtility.GetLastRect();
-                    listRect.y += 20;
                 }
 
+                ReorderableListGUI.Title("Variables");
+                VariableListAdaptor adaptor = new VariableListAdaptor(variablesProp, 0, w == 0 ? VariableListAdaptor.DefaultWidth : w);
+
+                ReorderableListFlags flags = ReorderableListFlags.DisableContextMenu | ReorderableListFlags.HideAddButton;
+
+                ReorderableListControl.DrawControlFromState(adaptor, null, flags);
+
+                listRect = GUILayoutUtility.GetLastRect();
+                
                 float plusWidth = 32;
                 float plusHeight = 24;
 

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -497,7 +497,7 @@ namespace Fungus.EditorUtils
                         GUILayout.Space(8);
 
                         FlowchartEditor flowchartEditor = Editor.CreateEditor (flowchart) as FlowchartEditor;
-                        flowchartEditor.DrawVariablesGUI();
+                        flowchartEditor.DrawVariablesGUI(true, 0);
                         DestroyImmediate(flowchartEditor);
 
                         Rect variableWindowRect = GUILayoutUtility.GetLastRect();

--- a/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
@@ -17,8 +17,7 @@ namespace Fungus
             // Have we loaded the prefs yet
             private static bool prefsLoaded = false;
 
-            public static bool hideMushroomInHierarchy,
-                               hideVariableInFlowchartInspector ;
+            public static bool hideMushroomInHierarchy;
 
             static FungusEditorPreferences()
             {
@@ -37,20 +36,17 @@ namespace Fungus
 
                 // Preferences GUI
                 hideMushroomInHierarchy = EditorGUILayout.Toggle("Hide Mushroom Flowchart Icon", hideMushroomInHierarchy);
-                hideVariableInFlowchartInspector = EditorGUILayout.Toggle("Hide Variables in Flowchart Inspector", hideVariableInFlowchartInspector);
 
                 // Save the preferences
                 if (GUI.changed)
                 {
                     EditorPrefs.SetBool("hideMushroomInHierarchy", hideMushroomInHierarchy);
-                    EditorPrefs.SetBool("hideVariableInFlowchartInspector", hideVariableInFlowchartInspector);
                 }
             }
 
             public static void LoadOnScriptLoad()
             {
                 hideMushroomInHierarchy = EditorPrefs.GetBool("hideMushroomInHierarchy", false);
-                hideVariableInFlowchartInspector = EditorPrefs.GetBool("hideVariableInFlowchartInspector", true);
                 prefsLoaded = true;
             }
         }

--- a/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using UnityEditor.Callbacks;
 
 namespace Fungus
 {
@@ -10,33 +11,47 @@ namespace Fungus
         /// 
         /// ref https://docs.unity3d.com/ScriptReference/PreferenceItem.html
         /// </summary>
-        public class FungusEditorPreferences
+        [InitializeOnLoad]
+        public static class FungusEditorPreferences
         {
             // Have we loaded the prefs yet
             private static bool prefsLoaded = false;
-            
-            public static bool hideMushroomInHierarchy = false;
+
+            public static bool hideMushroomInHierarchy,
+                               hideVariableInFlowchartInspector ;
+
+            static FungusEditorPreferences()
+            {
+                LoadOnScriptLoad();
+            }
 
             // Add preferences section named "My Preferences" to the Preferences Window
             [PreferenceItem("Fungus")]
-
             public static void PreferencesGUI()
             {
                 // Load the preferences
                 if (!prefsLoaded)
                 {
-                    hideMushroomInHierarchy = EditorPrefs.GetBool("hideMushroomInHierarchy", false);
-                    prefsLoaded = true;
+                    LoadOnScriptLoad();
                 }
 
                 // Preferences GUI
                 hideMushroomInHierarchy = EditorGUILayout.Toggle("Hide Mushroom Flowchart Icon", hideMushroomInHierarchy);
+                hideVariableInFlowchartInspector = EditorGUILayout.Toggle("Hide Variables in Flowchart Inspector", hideVariableInFlowchartInspector);
 
                 // Save the preferences
                 if (GUI.changed)
                 {
                     EditorPrefs.SetBool("hideMushroomInHierarchy", hideMushroomInHierarchy);
+                    EditorPrefs.SetBool("hideVariableInFlowchartInspector", hideVariableInFlowchartInspector);
                 }
+            }
+
+            public static void LoadOnScriptLoad()
+            {
+                hideMushroomInHierarchy = EditorPrefs.GetBool("hideMushroomInHierarchy", false);
+                hideVariableInFlowchartInspector = EditorPrefs.GetBool("hideVariableInFlowchartInspector", true);
+                prefsLoaded = true;
             }
         }
     }

--- a/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
@@ -15,6 +15,8 @@ namespace Fungus.EditorUtils
     public class VariableListAdaptor : IReorderableListAdaptor {
 
         public static readonly int DefaultWidth = 80 + 100 + 140 + 60;
+        public static readonly int ScrollSpacer = 8;
+        public static readonly int ReorderListSkirts = 70;
 
         protected SerializedProperty _arrayProperty;
 
@@ -38,7 +40,7 @@ namespace Fungus.EditorUtils
             
             this._arrayProperty = arrayProperty;
             this.fixedItemHeight = fixedItemHeight;
-            this.widthOfList = widthOfList;
+            this.widthOfList = widthOfList - ScrollSpacer;
         }
         
         public VariableListAdaptor(SerializedProperty arrayProperty) : this(arrayProperty, 0f, DefaultWidth) {

--- a/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
@@ -13,11 +13,15 @@ using Rotorz.ReorderableList;
 namespace Fungus.EditorUtils
 {
     public class VariableListAdaptor : IReorderableListAdaptor {
-        
+
+        public static readonly int DefaultWidth = 80 + 100 + 140 + 60;
+
         protected SerializedProperty _arrayProperty;
 
         public float fixedItemHeight;
-        
+        public int widthOfList;
+
+
         public SerializedProperty this[int index] {
             get { return _arrayProperty.GetArrayElementAtIndex(index); }
         }
@@ -26,7 +30,7 @@ namespace Fungus.EditorUtils
             get { return _arrayProperty; }
         }
         
-        public VariableListAdaptor(SerializedProperty arrayProperty, float fixedItemHeight) {
+        public VariableListAdaptor(SerializedProperty arrayProperty, float fixedItemHeight, int widthOfList) {
             if (arrayProperty == null)
                 throw new ArgumentNullException("Array property was null.");
             if (!arrayProperty.isArray)
@@ -34,9 +38,10 @@ namespace Fungus.EditorUtils
             
             this._arrayProperty = arrayProperty;
             this.fixedItemHeight = fixedItemHeight;
+            this.widthOfList = widthOfList;
         }
         
-        public VariableListAdaptor(SerializedProperty arrayProperty) : this(arrayProperty, 0f) {
+        public VariableListAdaptor(SerializedProperty arrayProperty) : this(arrayProperty, 0f, DefaultWidth) {
         }
                 
         public int Count {
@@ -103,7 +108,14 @@ namespace Fungus.EditorUtils
                 return;
             }
 
-            float[] widths = { 80, 100, 140, 60 };
+            int width = widthOfList;
+            int totalRatio = DefaultWidth;
+
+
+            float[] widths = { (80.0f/ totalRatio) * width,
+                (100.0f / totalRatio) * width,
+                (140.0f/ totalRatio) * width,
+                (60.0f/ totalRatio) * width };
             Rect[] rects = new Rect[4];
 
             for (int i = 0; i < 4; ++i)


### PR DESCRIPTION
-Refactored DrawVariablesGUI
-Added bool to FungusEditorPreferences, that hides the variable list in the flowchart inspector

Disabled by default in the FungusEditorPreferences.
Speeds up workflows that require tweaking a number of Fungus Variables on a number of Flowcharts and inspecting Fungus Variable state if the FlowchartEditor is not visible (low resolution screen, behind game view etc.)

![image](https://user-images.githubusercontent.com/4897812/31039098-3071aaac-a5be-11e7-9d82-6c9a9fb8067c.png)
