### PR TITLE
Account for SaveMenu DontDestroyOnLoad problems

### DIFF
--- a/Assets/Fungus/Scripts/Components/SaveMenu.cs
+++ b/Assets/Fungus/Scripts/Components/SaveMenu.cs
@@ -71,7 +71,14 @@ namespace Fungus
 
             instance = this;
 
-            GameObject.DontDestroyOnLoad(this);
+            if (transform.parent == null)
+            {
+                GameObject.DontDestroyOnLoad(this);
+            }
+            else
+            {
+                Debug.LogError("Save Menu cannot be preserved across scene loads if it is a child of another GameObject.");
+            }
 
             clickAudioSource = GetComponent<AudioSource>();
         }

--- a/Assets/Fungus/Scripts/Components/SaveMenu.cs
+++ b/Assets/Fungus/Scripts/Components/SaveMenu.cs
@@ -58,6 +58,8 @@ namespace Fungus
 
         protected static SaveMenu instance;
 
+        protected static bool hasLoadedOnStart = false;
+
         protected virtual void Awake()
         {
             // Only one instance of SaveMenu may exist
@@ -89,8 +91,10 @@ namespace Fungus
                 saveManager.StartScene = SceneManager.GetActiveScene().name;
             }
 
-            if (loadOnStart)
+            if (loadOnStart && !hasLoadedOnStart)
             {
+                hasLoadedOnStart = true;
+
                 if (saveManager.SaveDataExists(saveDataKey))
                 {
                     saveManager.Load(saveDataKey);


### PR DESCRIPTION
Threw in some infinite loop prevention when the SaveMenu is nested inside other GameObjects (and therefore the DontDestroyOnLoad method doesn't work). Also logs a more context-aware error when the SaveMenu is nested inside another GameObject.

This is my first time contributing. Please let me know if there's anything I could do better.

For further details, see [this issue](https://github.com/snozbot/fungus/issues/657#issuecomment-372126664).