### PR TITLE
Set and compare other variables

### DIFF
--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -29,7 +29,9 @@ namespace Fungus
                           typeof(Rigidbody2DVariable),
                           typeof(SpriteVariable),
                           typeof(TextureVariable),
-                          typeof(TransformVariable))]
+                          typeof(TransformVariable),
+                          typeof(Vector2Variable),
+                          typeof(Vector3Variable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -76,6 +78,12 @@ namespace Fungus
 
         [Tooltip("Transform value to set with")]
         [SerializeField] protected TransformData transformData;
+
+        [Tooltip("Vector2 value to set with")]
+        [SerializeField] protected Vector2Data vector2Data;
+
+        [Tooltip("Vector3 value to set with")]
+        [SerializeField] protected Vector3Data vector3Data;
 
         protected virtual void DoSetOperation()
         {
@@ -155,6 +163,16 @@ namespace Fungus
                 TransformVariable transformVariable = (variable as TransformVariable);
                 transformVariable.Apply(setOperator, transformData.Value);
             }
+            else if (variable.GetType() == typeof(Vector2Variable))
+            {
+                Vector2Variable vector2Variable = (variable as Vector2Variable);
+                vector2Variable.Apply(setOperator, vector2Data.Value);
+            }
+            else if (variable.GetType() == typeof(Vector3Variable))
+            {
+                Vector3Variable vector3Variable = (variable as Vector3Variable);
+                vector3Variable.Apply(setOperator, vector3Data.Value);
+            }
         }
 
         #region Public members
@@ -173,7 +191,9 @@ namespace Fungus
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators },
             { typeof(SpriteVariable), SpriteVariable.setOperators },
             { typeof(TextureVariable), TextureVariable.setOperators },
-            { typeof(TransformVariable), TransformVariable.setOperators }
+            { typeof(TransformVariable), TransformVariable.setOperators },
+            { typeof(Vector2Variable), Vector2Variable.setOperators },
+            { typeof(Vector3Variable), Vector3Variable.setOperators }
         };
 
         /// <summary>
@@ -275,6 +295,14 @@ namespace Fungus
             else if (variable.GetType() == typeof(TransformVariable))
             {
                 description += transformData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Vector2Variable))
+            {
+                description += vector2Data.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Vector3Variable))
+            {
+                description += vector3Data.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -20,6 +20,7 @@ namespace Fungus
                           typeof(IntegerVariable), 
                           typeof(FloatVariable), 
                           typeof(StringVariable),
+                          typeof(AnimatorVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -37,6 +38,9 @@ namespace Fungus
 
         [Tooltip("String value to set with")]
         [SerializeField] protected StringDataMulti stringData;
+
+        [Tooltip("Animator value to set with")]
+        [SerializeField] protected AnimatorData animatorData;
 
         [Tooltip("GameObject value to set with")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -69,6 +73,11 @@ namespace Fungus
                 var flowchart = GetFlowchart();
                 stringVariable.Apply(setOperator, flowchart.SubstituteVariables(stringData.Value));
             }
+            else if (variable.GetType() == typeof(AnimatorVariable))
+            {
+                AnimatorVariable animatorVariable = (variable as AnimatorVariable);
+                animatorVariable.Apply(setOperator, animatorData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -83,6 +92,7 @@ namespace Fungus
             { typeof(IntegerVariable), IntegerVariable.setOperators },
             { typeof(FloatVariable), FloatVariable.setOperators },
             { typeof(StringVariable), StringVariable.setOperators },
+            { typeof(AnimatorVariable), AnimatorVariable.setOperators },
             { typeof(GameObjectVariable), GameObjectVariable.setOperators }
         };
 
@@ -145,6 +155,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(StringVariable))
             {
                 description += stringData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(AnimatorVariable))
+            {
+                description += animatorData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -26,7 +26,8 @@ namespace Fungus
                           typeof(GameObjectVariable),
                           typeof(MaterialVariable),
                           typeof(ObjectVariable),
-                          typeof(Rigidbody2DVariable))]
+                          typeof(Rigidbody2DVariable),
+                          typeof(SpriteVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -64,6 +65,9 @@ namespace Fungus
 
         [Tooltip("Rigidbody2D value to set with")]
         [SerializeField] protected Rigidbody2DData rigidbody2DData;
+
+        [Tooltip("Sprite value to set with")]
+        [SerializeField] protected SpriteData spriteData;
 
         protected virtual void DoSetOperation()
         {
@@ -128,6 +132,11 @@ namespace Fungus
                 Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
                 rigidbody2DVariable.Apply(setOperator, rigidbody2DData.Value);
             }
+            else if (variable.GetType() == typeof(SpriteVariable))
+            {
+                SpriteVariable spriteVariable = (variable as SpriteVariable);
+                spriteVariable.Apply(setOperator, spriteData.Value);
+            }
         }
 
         #region Public members
@@ -143,7 +152,8 @@ namespace Fungus
             { typeof(GameObjectVariable), GameObjectVariable.setOperators },
             { typeof(MaterialVariable), MaterialVariable.setOperators },
             { typeof(ObjectVariable), ObjectVariable.setOperators },
-            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators }
+            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators },
+            { typeof(SpriteVariable), SpriteVariable.setOperators }
         };
 
         /// <summary>
@@ -233,6 +243,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(Rigidbody2DVariable))
             {
                 description += rigidbody2DData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(SpriteVariable))
+            {
+                description += spriteData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -24,7 +24,8 @@ namespace Fungus
                           typeof(AudioSourceVariable),
                           typeof(ColorVariable),
                           typeof(GameObjectVariable),
-                          typeof(MaterialVariable))]
+                          typeof(MaterialVariable),
+                          typeof(ObjectVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -56,6 +57,9 @@ namespace Fungus
 
         [Tooltip("Material value to set with")]
         [SerializeField] protected MaterialData materialData;
+
+        [Tooltip("Object value to set with")]
+        [SerializeField] protected ObjectData objectData;
 
         protected virtual void DoSetOperation()
         {
@@ -110,6 +114,11 @@ namespace Fungus
                 MaterialVariable materialVariable = (variable as MaterialVariable);
                 materialVariable.Apply(setOperator, materialData.Value);
             }
+            else if (variable.GetType() == typeof(ObjectVariable))
+            {
+                ObjectVariable objectVariable = (variable as ObjectVariable);
+                objectVariable.Apply(setOperator, objectData.Value);
+            }
         }
 
         #region Public members
@@ -123,7 +132,8 @@ namespace Fungus
             { typeof(AudioSourceVariable), AudioSourceVariable.setOperators },
             { typeof(ColorVariable), ColorVariable.setOperators },
             { typeof(GameObjectVariable), GameObjectVariable.setOperators },
-            { typeof(MaterialVariable), MaterialVariable.setOperators }
+            { typeof(MaterialVariable), MaterialVariable.setOperators },
+            { typeof(ObjectVariable), ObjectVariable.setOperators }
         };
 
         /// <summary>
@@ -205,6 +215,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(MaterialVariable))
             {
                 description += materialData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(ObjectVariable))
+            {
+                description += objectData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -9,21 +9,22 @@ namespace Fungus
     /// <summary>
     /// Sets a Boolean, Integer, Float or String variable to a new value using a simple arithmetic operation. The value can be a constant or reference another variable of the same type.
     /// </summary>
-    [CommandInfo("Variable", 
-                 "Set Variable", 
+    [CommandInfo("Variable",
+                 "Set Variable",
                  "Sets a Boolean, Integer, Float or String variable to a new value using a simple arithmetic operation. The value can be a constant or reference another variable of the same type.")]
     [AddComponentMenu("")]
-    public class SetVariable : Command 
+    public class SetVariable : Command
     {
         [Tooltip("The variable whos value will be set")]
         [VariableProperty(typeof(BooleanVariable),
-                          typeof(IntegerVariable), 
-                          typeof(FloatVariable), 
+                          typeof(IntegerVariable),
+                          typeof(FloatVariable),
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
                           typeof(AudioSourceVariable),
                           typeof(ColorVariable),
-                          typeof(GameObjectVariable))]
+                          typeof(GameObjectVariable),
+                          typeof(MaterialVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -52,6 +53,9 @@ namespace Fungus
 
         [Tooltip("GameObject value to set with")]
         [SerializeField] protected GameObjectData gameObjectData;
+
+        [Tooltip("Material value to set with")]
+        [SerializeField] protected MaterialData materialData;
 
         protected virtual void DoSetOperation()
         {
@@ -101,6 +105,11 @@ namespace Fungus
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
                 gameObjectVariable.Apply(setOperator, gameObjectData.Value);
             }
+            else if (variable.GetType() == typeof(MaterialVariable))
+            {
+                MaterialVariable materialVariable = (variable as MaterialVariable);
+                materialVariable.Apply(setOperator, materialData.Value);
+            }
         }
 
         #region Public members
@@ -113,7 +122,8 @@ namespace Fungus
             { typeof(AnimatorVariable), AnimatorVariable.setOperators },
             { typeof(AudioSourceVariable), AudioSourceVariable.setOperators },
             { typeof(ColorVariable), ColorVariable.setOperators },
-            { typeof(GameObjectVariable), GameObjectVariable.setOperators }
+            { typeof(GameObjectVariable), GameObjectVariable.setOperators },
+            { typeof(MaterialVariable), MaterialVariable.setOperators }
         };
 
         /// <summary>
@@ -191,6 +201,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 description += gameObjectData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(MaterialVariable))
+            {
+                description += materialData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -21,6 +21,7 @@ namespace Fungus
                           typeof(FloatVariable), 
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
+                          typeof(AudioSourceVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -41,6 +42,9 @@ namespace Fungus
 
         [Tooltip("Animator value to set with")]
         [SerializeField] protected AnimatorData animatorData;
+
+        [Tooltip("AudioSource value to set with")]
+        [SerializeField] protected AudioSourceData audioSourceData;
 
         [Tooltip("GameObject value to set with")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -78,6 +82,11 @@ namespace Fungus
                 AnimatorVariable animatorVariable = (variable as AnimatorVariable);
                 animatorVariable.Apply(setOperator, animatorData.Value);
             }
+            else if (variable.GetType() == typeof(AudioSourceVariable))
+            {
+                AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
+                audioSourceVariable.Apply(setOperator, audioSourceData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -93,6 +102,7 @@ namespace Fungus
             { typeof(FloatVariable), FloatVariable.setOperators },
             { typeof(StringVariable), StringVariable.setOperators },
             { typeof(AnimatorVariable), AnimatorVariable.setOperators },
+            { typeof(AudioSourceVariable), AudioSourceVariable.setOperators },
             { typeof(GameObjectVariable), GameObjectVariable.setOperators }
         };
 
@@ -159,6 +169,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(AnimatorVariable))
             {
                 description += animatorData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(AudioSourceVariable))
+            {
+                description += audioSourceData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -27,7 +27,8 @@ namespace Fungus
                           typeof(MaterialVariable),
                           typeof(ObjectVariable),
                           typeof(Rigidbody2DVariable),
-                          typeof(SpriteVariable))]
+                          typeof(SpriteVariable),
+                          typeof(TextureVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -68,6 +69,9 @@ namespace Fungus
 
         [Tooltip("Sprite value to set with")]
         [SerializeField] protected SpriteData spriteData;
+
+        [Tooltip("Texture value to set with")]
+        [SerializeField] protected TextureData textureData;
 
         protected virtual void DoSetOperation()
         {
@@ -137,6 +141,11 @@ namespace Fungus
                 SpriteVariable spriteVariable = (variable as SpriteVariable);
                 spriteVariable.Apply(setOperator, spriteData.Value);
             }
+            else if (variable.GetType() == typeof(TextureVariable))
+            {
+                TextureVariable textureVariable = (variable as TextureVariable);
+                textureVariable.Apply(setOperator, textureData.Value);
+            }
         }
 
         #region Public members
@@ -153,7 +162,8 @@ namespace Fungus
             { typeof(MaterialVariable), MaterialVariable.setOperators },
             { typeof(ObjectVariable), ObjectVariable.setOperators },
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators },
-            { typeof(SpriteVariable), SpriteVariable.setOperators }
+            { typeof(SpriteVariable), SpriteVariable.setOperators },
+            { typeof(TextureVariable), TextureVariable.setOperators }
         };
 
         /// <summary>
@@ -247,6 +257,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(SpriteVariable))
             {
                 description += spriteData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(TextureVariable))
+            {
+                description += textureData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -28,7 +28,8 @@ namespace Fungus
                           typeof(ObjectVariable),
                           typeof(Rigidbody2DVariable),
                           typeof(SpriteVariable),
-                          typeof(TextureVariable))]
+                          typeof(TextureVariable),
+                          typeof(TransformVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -72,6 +73,9 @@ namespace Fungus
 
         [Tooltip("Texture value to set with")]
         [SerializeField] protected TextureData textureData;
+
+        [Tooltip("Transform value to set with")]
+        [SerializeField] protected TransformData transformData;
 
         protected virtual void DoSetOperation()
         {
@@ -146,6 +150,11 @@ namespace Fungus
                 TextureVariable textureVariable = (variable as TextureVariable);
                 textureVariable.Apply(setOperator, textureData.Value);
             }
+            else if (variable.GetType() == typeof(TransformVariable))
+            {
+                TransformVariable transformVariable = (variable as TransformVariable);
+                transformVariable.Apply(setOperator, transformData.Value);
+            }
         }
 
         #region Public members
@@ -163,7 +172,8 @@ namespace Fungus
             { typeof(ObjectVariable), ObjectVariable.setOperators },
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators },
             { typeof(SpriteVariable), SpriteVariable.setOperators },
-            { typeof(TextureVariable), TextureVariable.setOperators }
+            { typeof(TextureVariable), TextureVariable.setOperators },
+            { typeof(TransformVariable), TransformVariable.setOperators }
         };
 
         /// <summary>
@@ -261,6 +271,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(TextureVariable))
             {
                 description += textureData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(TransformVariable))
+            {
+                description += transformData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -25,7 +25,8 @@ namespace Fungus
                           typeof(ColorVariable),
                           typeof(GameObjectVariable),
                           typeof(MaterialVariable),
-                          typeof(ObjectVariable))]
+                          typeof(ObjectVariable),
+                          typeof(Rigidbody2DVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("The type of math operation to be performed")]
@@ -60,6 +61,9 @@ namespace Fungus
 
         [Tooltip("Object value to set with")]
         [SerializeField] protected ObjectData objectData;
+
+        [Tooltip("Rigidbody2D value to set with")]
+        [SerializeField] protected Rigidbody2DData rigidbody2DData;
 
         protected virtual void DoSetOperation()
         {
@@ -119,6 +123,11 @@ namespace Fungus
                 ObjectVariable objectVariable = (variable as ObjectVariable);
                 objectVariable.Apply(setOperator, objectData.Value);
             }
+            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            {
+                Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
+                rigidbody2DVariable.Apply(setOperator, rigidbody2DData.Value);
+            }
         }
 
         #region Public members
@@ -133,7 +142,8 @@ namespace Fungus
             { typeof(ColorVariable), ColorVariable.setOperators },
             { typeof(GameObjectVariable), GameObjectVariable.setOperators },
             { typeof(MaterialVariable), MaterialVariable.setOperators },
-            { typeof(ObjectVariable), ObjectVariable.setOperators }
+            { typeof(ObjectVariable), ObjectVariable.setOperators },
+            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.setOperators }
         };
 
         /// <summary>
@@ -219,6 +229,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(ObjectVariable))
             {
                 description += objectData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            {
+                description += rigidbody2DData.GetDescription();
             }
 
             return description;

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -22,6 +22,7 @@ namespace Fungus
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
                           typeof(AudioSourceVariable),
+                          typeof(ColorVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -45,6 +46,9 @@ namespace Fungus
 
         [Tooltip("AudioSource value to set with")]
         [SerializeField] protected AudioSourceData audioSourceData;
+
+        [Tooltip("Color value to set with")]
+        [SerializeField] protected ColorData colorData;
 
         [Tooltip("GameObject value to set with")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -87,6 +91,11 @@ namespace Fungus
                 AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
                 audioSourceVariable.Apply(setOperator, audioSourceData.Value);
             }
+            else if (variable.GetType() == typeof(ColorVariable))
+            {
+                ColorVariable colorVariable = (variable as ColorVariable);
+                colorVariable.Apply(setOperator, colorData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -103,6 +112,7 @@ namespace Fungus
             { typeof(StringVariable), StringVariable.setOperators },
             { typeof(AnimatorVariable), AnimatorVariable.setOperators },
             { typeof(AudioSourceVariable), AudioSourceVariable.setOperators },
+            { typeof(ColorVariable), ColorVariable.setOperators },
             { typeof(GameObjectVariable), GameObjectVariable.setOperators }
         };
 
@@ -173,6 +183,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(AudioSourceVariable))
             {
                 description += audioSourceData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(ColorVariable))
+            {
+                description += colorData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -24,7 +24,8 @@ namespace Fungus
                           typeof(ObjectVariable),
                           typeof(Rigidbody2DVariable),
                           typeof(SpriteVariable),
-                          typeof(TextureVariable))]
+                          typeof(TextureVariable),
+                          typeof(TransformVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -65,6 +66,9 @@ namespace Fungus
 
         [Tooltip("Texture value to compare against")]
         [SerializeField] protected TextureData textureData;
+
+        [Tooltip("Transform value to compare against")]
+        [SerializeField] protected TransformData transformData;
 
         protected override bool EvaluateCondition()
         {
@@ -140,6 +144,11 @@ namespace Fungus
                 TextureVariable textureVariable = (variable as TextureVariable);
                 condition = textureVariable.Evaluate(compareOperator, textureData.Value);
             }
+            else if (variable.GetType() == typeof(TransformVariable))
+            {
+                TransformVariable transformVariable = (variable as TransformVariable);
+                condition = transformVariable.Evaluate(compareOperator, transformData.Value);
+            }
 
             return condition;
         }
@@ -164,7 +173,8 @@ namespace Fungus
             { typeof(ObjectVariable), ObjectVariable.compareOperators },
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators },
             { typeof(SpriteVariable), SpriteVariable.compareOperators },
-            { typeof(TextureVariable), TextureVariable.compareOperators }
+            { typeof(TextureVariable), TextureVariable.compareOperators },
+            { typeof(TransformVariable), TransformVariable.compareOperators }
         };
 
         /// <summary>
@@ -233,6 +243,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(TextureVariable))
             {
                 summary += textureData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(TransformVariable))
+            {
+                summary += transformData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -25,7 +25,9 @@ namespace Fungus
                           typeof(Rigidbody2DVariable),
                           typeof(SpriteVariable),
                           typeof(TextureVariable),
-                          typeof(TransformVariable))]
+                          typeof(TransformVariable),
+                          typeof(Vector2Variable),
+                          typeof(Vector3Variable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -69,6 +71,12 @@ namespace Fungus
 
         [Tooltip("Transform value to compare against")]
         [SerializeField] protected TransformData transformData;
+
+        [Tooltip("Vector2 value to compare against")]
+        [SerializeField] protected Vector2Data vector2Data;
+
+        [Tooltip("Vector3 value to compare against")]
+        [SerializeField] protected Vector3Data vector3Data;
 
         protected override bool EvaluateCondition()
         {
@@ -149,6 +157,16 @@ namespace Fungus
                 TransformVariable transformVariable = (variable as TransformVariable);
                 condition = transformVariable.Evaluate(compareOperator, transformData.Value);
             }
+            else if (variable.GetType() == typeof(Vector2Variable))
+            {
+                Vector2Variable vector2Variable = (variable as Vector2Variable);
+                condition = vector2Variable.Evaluate(compareOperator, vector2Data.Value);
+            }
+            else if (variable.GetType() == typeof(Vector3Variable))
+            {
+                Vector3Variable vector3Variable = (variable as Vector3Variable);
+                condition = vector3Variable.Evaluate(compareOperator, vector3Data.Value);
+            }
 
             return condition;
         }
@@ -174,7 +192,9 @@ namespace Fungus
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators },
             { typeof(SpriteVariable), SpriteVariable.compareOperators },
             { typeof(TextureVariable), TextureVariable.compareOperators },
-            { typeof(TransformVariable), TransformVariable.compareOperators }
+            { typeof(TransformVariable), TransformVariable.compareOperators },
+            { typeof(Vector2Variable), Vector2Variable.compareOperators },
+            { typeof(Vector3Variable), Vector3Variable.compareOperators }
         };
 
         /// <summary>
@@ -247,6 +267,14 @@ namespace Fungus
             else if (variable.GetType() == typeof(TransformVariable))
             {
                 summary += transformData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Vector2Variable))
+            {
+                summary += vector2Data.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Vector3Variable))
+            {
+                summary += vector3Data.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -16,6 +16,7 @@ namespace Fungus
                           typeof(IntegerVariable), 
                           typeof(FloatVariable), 
                           typeof(StringVariable),
+                          typeof(AnimatorVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -30,6 +31,9 @@ namespace Fungus
 
         [Tooltip("String value to compare against")]
         [SerializeField] protected StringDataMulti stringData;
+
+        [Tooltip("Animator value to compare against")]
+        [SerializeField] protected AnimatorData animatorData;
 
         [Tooltip("GameObject value to compare against")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -63,6 +67,11 @@ namespace Fungus
                 StringVariable stringVariable = (variable as StringVariable);
                 condition = stringVariable.Evaluate(compareOperator, stringData.Value);
             }
+            else if (variable.GetType() == typeof(AnimatorVariable))
+            {
+                AnimatorVariable animatorVariable = (variable as AnimatorVariable);
+                condition = animatorVariable.Evaluate(compareOperator, animatorData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -84,6 +93,7 @@ namespace Fungus
             { typeof(IntegerVariable), IntegerVariable.compareOperators },
             { typeof(FloatVariable), FloatVariable.compareOperators },
             { typeof(StringVariable), StringVariable.compareOperators },
+            { typeof(AnimatorVariable), AnimatorVariable.compareOperators },
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators }
         };
 
@@ -117,6 +127,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(StringVariable))
             {
                 summary += stringData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(AnimatorVariable))
+            {
+                summary += animatorData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -21,7 +21,8 @@ namespace Fungus
                           typeof(ColorVariable),
                           typeof(GameObjectVariable),
                           typeof(MaterialVariable),
-                          typeof(ObjectVariable))]
+                          typeof(ObjectVariable),
+                          typeof(Rigidbody2DVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -53,6 +54,9 @@ namespace Fungus
 
         [Tooltip("Object value to compare against")]
         [SerializeField] protected ObjectData objectData;
+
+        [Tooltip("Rigidbody2D value to compare against")]
+        [SerializeField] protected Rigidbody2DData rigidbody2DData;
 
         protected override bool EvaluateCondition()
         {
@@ -113,6 +117,11 @@ namespace Fungus
                 ObjectVariable objectVariable = (variable as ObjectVariable);
                 condition = objectVariable.Evaluate(compareOperator, objectData.Value);
             }
+            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            {
+                Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
+                condition = rigidbody2DVariable.Evaluate(compareOperator, rigidbody2DData.Value);
+            }
 
             return condition;
         }
@@ -134,7 +143,8 @@ namespace Fungus
             { typeof(ColorVariable), ColorVariable.compareOperators },
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators },
             { typeof(MaterialVariable), MaterialVariable.compareOperators },
-            { typeof(ObjectVariable), ObjectVariable.compareOperators }
+            { typeof(ObjectVariable), ObjectVariable.compareOperators },
+            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators }
         };
 
         /// <summary>
@@ -191,6 +201,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(ObjectVariable))
             {
                 summary += objectData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            {
+                summary += rigidbody2DData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -22,7 +22,8 @@ namespace Fungus
                           typeof(GameObjectVariable),
                           typeof(MaterialVariable),
                           typeof(ObjectVariable),
-                          typeof(Rigidbody2DVariable))]
+                          typeof(Rigidbody2DVariable),
+                          typeof(SpriteVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -57,6 +58,9 @@ namespace Fungus
 
         [Tooltip("Rigidbody2D value to compare against")]
         [SerializeField] protected Rigidbody2DData rigidbody2DData;
+
+        [Tooltip("Sprite value to compare against")]
+        [SerializeField] protected SpriteData spriteData;
 
         protected override bool EvaluateCondition()
         {
@@ -122,6 +126,11 @@ namespace Fungus
                 Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
                 condition = rigidbody2DVariable.Evaluate(compareOperator, rigidbody2DData.Value);
             }
+            else if (variable.GetType() == typeof(SpriteVariable))
+            {
+                SpriteVariable spriteVariable = (variable as SpriteVariable);
+                condition = spriteVariable.Evaluate(compareOperator, spriteData.Value);
+            }
 
             return condition;
         }
@@ -144,7 +153,8 @@ namespace Fungus
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators },
             { typeof(MaterialVariable), MaterialVariable.compareOperators },
             { typeof(ObjectVariable), ObjectVariable.compareOperators },
-            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators }
+            { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators },
+            { typeof(SpriteVariable), SpriteVariable.compareOperators }
         };
 
         /// <summary>
@@ -205,6 +215,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(Rigidbody2DVariable))
             {
                 summary += rigidbody2DData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(SpriteVariable))
+            {
+                summary += spriteData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -23,7 +23,8 @@ namespace Fungus
                           typeof(MaterialVariable),
                           typeof(ObjectVariable),
                           typeof(Rigidbody2DVariable),
-                          typeof(SpriteVariable))]
+                          typeof(SpriteVariable),
+                          typeof(TextureVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -61,6 +62,9 @@ namespace Fungus
 
         [Tooltip("Sprite value to compare against")]
         [SerializeField] protected SpriteData spriteData;
+
+        [Tooltip("Texture value to compare against")]
+        [SerializeField] protected TextureData textureData;
 
         protected override bool EvaluateCondition()
         {
@@ -131,6 +135,11 @@ namespace Fungus
                 SpriteVariable spriteVariable = (variable as SpriteVariable);
                 condition = spriteVariable.Evaluate(compareOperator, spriteData.Value);
             }
+            else if (variable.GetType() == typeof(TextureVariable))
+            {
+                TextureVariable textureVariable = (variable as TextureVariable);
+                condition = textureVariable.Evaluate(compareOperator, textureData.Value);
+            }
 
             return condition;
         }
@@ -154,7 +163,8 @@ namespace Fungus
             { typeof(MaterialVariable), MaterialVariable.compareOperators },
             { typeof(ObjectVariable), ObjectVariable.compareOperators },
             { typeof(Rigidbody2DVariable), Rigidbody2DVariable.compareOperators },
-            { typeof(SpriteVariable), SpriteVariable.compareOperators }
+            { typeof(SpriteVariable), SpriteVariable.compareOperators },
+            { typeof(TextureVariable), TextureVariable.compareOperators }
         };
 
         /// <summary>
@@ -219,6 +229,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(SpriteVariable))
             {
                 summary += spriteData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(TextureVariable))
+            {
+                summary += textureData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -20,7 +20,8 @@ namespace Fungus
                           typeof(AudioSourceVariable),
                           typeof(ColorVariable),
                           typeof(GameObjectVariable),
-                          typeof(MaterialVariable))]
+                          typeof(MaterialVariable),
+                          typeof(ObjectVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -49,6 +50,9 @@ namespace Fungus
 
         [Tooltip("Material value to compare against")]
         [SerializeField] protected MaterialData materialData;
+
+        [Tooltip("Object value to compare against")]
+        [SerializeField] protected ObjectData objectData;
 
         protected override bool EvaluateCondition()
         {
@@ -104,6 +108,11 @@ namespace Fungus
                 MaterialVariable materialVariable = (variable as MaterialVariable);
                 condition = materialVariable.Evaluate(compareOperator, materialData.Value);
             }
+            else if (variable.GetType() == typeof(ObjectVariable))
+            {
+                ObjectVariable objectVariable = (variable as ObjectVariable);
+                condition = objectVariable.Evaluate(compareOperator, objectData.Value);
+            }
 
             return condition;
         }
@@ -124,7 +133,8 @@ namespace Fungus
             { typeof(AudioSourceVariable), AudioSourceVariable.compareOperators },
             { typeof(ColorVariable), ColorVariable.compareOperators },
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators },
-            { typeof(MaterialVariable), MaterialVariable.compareOperators }
+            { typeof(MaterialVariable), MaterialVariable.compareOperators },
+            { typeof(ObjectVariable), ObjectVariable.compareOperators }
         };
 
         /// <summary>
@@ -177,6 +187,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(MaterialVariable))
             {
                 summary += materialData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(ObjectVariable))
+            {
+                summary += objectData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -13,13 +13,14 @@ namespace Fungus
 
         [Tooltip("Variable to use in expression")]
         [VariableProperty(typeof(BooleanVariable),
-                          typeof(IntegerVariable), 
-                          typeof(FloatVariable), 
+                          typeof(IntegerVariable),
+                          typeof(FloatVariable),
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
                           typeof(AudioSourceVariable),
                           typeof(ColorVariable),
-                          typeof(GameObjectVariable))]
+                          typeof(GameObjectVariable),
+                          typeof(MaterialVariable))]
         [SerializeField] protected Variable variable;
 
         [Tooltip("Boolean value to compare against")]
@@ -45,6 +46,9 @@ namespace Fungus
 
         [Tooltip("GameObject value to compare against")]
         [SerializeField] protected GameObjectData gameObjectData;
+
+        [Tooltip("Material value to compare against")]
+        [SerializeField] protected MaterialData materialData;
 
         protected override bool EvaluateCondition()
         {
@@ -95,6 +99,11 @@ namespace Fungus
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
                 condition = gameObjectVariable.Evaluate(compareOperator, gameObjectData.Value);
             }
+            else if (variable.GetType() == typeof(MaterialVariable))
+            {
+                MaterialVariable materialVariable = (variable as MaterialVariable);
+                condition = materialVariable.Evaluate(compareOperator, materialData.Value);
+            }
 
             return condition;
         }
@@ -114,7 +123,8 @@ namespace Fungus
             { typeof(AnimatorVariable), AnimatorVariable.compareOperators },
             { typeof(AudioSourceVariable), AudioSourceVariable.compareOperators },
             { typeof(ColorVariable), ColorVariable.compareOperators },
-            { typeof(GameObjectVariable), GameObjectVariable.compareOperators }
+            { typeof(GameObjectVariable), GameObjectVariable.compareOperators },
+            { typeof(MaterialVariable), MaterialVariable.compareOperators }
         };
 
         /// <summary>
@@ -163,6 +173,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 summary += gameObjectData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(MaterialVariable))
+            {
+                summary += materialData.GetDescription();
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -18,6 +18,7 @@ namespace Fungus
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
                           typeof(AudioSourceVariable),
+                          typeof(ColorVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -38,6 +39,9 @@ namespace Fungus
 
         [Tooltip("AudioSource value to compare against")]
         [SerializeField] protected AudioSourceData audioSourceData;
+
+        [Tooltip("Color value to compare against")]
+        [SerializeField] protected ColorData colorData;
 
         [Tooltip("GameObject value to compare against")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -81,6 +85,11 @@ namespace Fungus
                 AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
                 condition = audioSourceVariable.Evaluate(compareOperator, audioSourceData.Value);
             }
+            else if (variable.GetType() == typeof(ColorVariable))
+            {
+                ColorVariable colorVariable = (variable as ColorVariable);
+                condition = colorVariable.Evaluate(compareOperator, colorData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -104,6 +113,7 @@ namespace Fungus
             { typeof(StringVariable), StringVariable.compareOperators },
             { typeof(AnimatorVariable), AnimatorVariable.compareOperators },
             { typeof(AudioSourceVariable), AudioSourceVariable.compareOperators },
+            { typeof(ColorVariable), ColorVariable.compareOperators },
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators }
         };
 
@@ -145,6 +155,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(AudioSourceVariable))
             {
                 summary += audioSourceData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(ColorVariable))
+            {
+                summary += colorData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -17,6 +17,7 @@ namespace Fungus
                           typeof(FloatVariable), 
                           typeof(StringVariable),
                           typeof(AnimatorVariable),
+                          typeof(AudioSourceVariable),
                           typeof(GameObjectVariable))]
         [SerializeField] protected Variable variable;
 
@@ -34,6 +35,9 @@ namespace Fungus
 
         [Tooltip("Animator value to compare against")]
         [SerializeField] protected AnimatorData animatorData;
+
+        [Tooltip("AudioSource value to compare against")]
+        [SerializeField] protected AudioSourceData audioSourceData;
 
         [Tooltip("GameObject value to compare against")]
         [SerializeField] protected GameObjectData gameObjectData;
@@ -72,6 +76,11 @@ namespace Fungus
                 AnimatorVariable animatorVariable = (variable as AnimatorVariable);
                 condition = animatorVariable.Evaluate(compareOperator, animatorData.Value);
             }
+            else if (variable.GetType() == typeof(AudioSourceVariable))
+            {
+                AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
+                condition = audioSourceVariable.Evaluate(compareOperator, audioSourceData.Value);
+            }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
@@ -94,6 +103,7 @@ namespace Fungus
             { typeof(FloatVariable), FloatVariable.compareOperators },
             { typeof(StringVariable), StringVariable.compareOperators },
             { typeof(AnimatorVariable), AnimatorVariable.compareOperators },
+            { typeof(AudioSourceVariable), AudioSourceVariable.compareOperators },
             { typeof(GameObjectVariable), GameObjectVariable.compareOperators }
         };
 
@@ -131,6 +141,10 @@ namespace Fungus
             else if (variable.GetType() == typeof(AnimatorVariable))
             {
                 summary += animatorData.GetDescription();
+            }
+            else if (variable.GetType() == typeof(AudioSourceVariable))
+            {
+                summary += audioSourceData.GetDescription();
             }
             else if (variable.GetType() == typeof(GameObjectVariable))
             {

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -9,7 +9,7 @@ namespace Fungus.EditorUtils
 {
 
     [CustomEditor (typeof(SetVariable))]
-    public class SetVariableEditor : CommandEditor 
+    public class SetVariableEditor : CommandEditor
     {
         protected struct VariablePropertyInfo
         {
@@ -46,6 +46,7 @@ namespace Fungus.EditorUtils
                 { typeof(StringVariable), new VariablePropertyInfo("String", serializedObject.FindProperty("stringData")) },
                 { typeof(AnimatorVariable), new VariablePropertyInfo("Animator", serializedObject.FindProperty("animatorData")) },
                 { typeof(AudioSourceVariable), new VariablePropertyInfo("AudioSource", serializedObject.FindProperty("audioSourceData")) },
+                { typeof(ColorVariable), new VariablePropertyInfo("Color", serializedObject.FindProperty("colorData")) },
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) }
             };
         }
@@ -107,7 +108,7 @@ namespace Fungus.EditorUtils
                         break;
                 }
             }
-            
+
             // Get previously selected operator
             int selectedIndex = System.Array.IndexOf(setOperators, t._SetOperator);
             if (selectedIndex < 0)
@@ -119,7 +120,7 @@ namespace Fungus.EditorUtils
 
             // Get next selected operator
             selectedIndex = EditorGUILayout.Popup(new GUIContent("Operation", "Arithmetic operator to use"), selectedIndex, operatorsList.ToArray());
-            
+
 
             setOperatorProp.enumValueIndex = (int)setOperators[selectedIndex];
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -48,7 +48,8 @@ namespace Fungus.EditorUtils
                 { typeof(AudioSourceVariable), new VariablePropertyInfo("AudioSource", serializedObject.FindProperty("audioSourceData")) },
                 { typeof(ColorVariable), new VariablePropertyInfo("Color", serializedObject.FindProperty("colorData")) },
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) },
-                { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) }
+                { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) },
+                { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -45,6 +45,7 @@ namespace Fungus.EditorUtils
                 { typeof(FloatVariable), new VariablePropertyInfo("Float", serializedObject.FindProperty("floatData")) },
                 { typeof(StringVariable), new VariablePropertyInfo("String", serializedObject.FindProperty("stringData")) },
                 { typeof(AnimatorVariable), new VariablePropertyInfo("Animator", serializedObject.FindProperty("animatorData")) },
+                { typeof(AudioSourceVariable), new VariablePropertyInfo("AudioSource", serializedObject.FindProperty("audioSourceData")) },
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) }
             };
         }

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -51,7 +51,8 @@ namespace Fungus.EditorUtils
                 { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) },
                 { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) },
                 { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) },
-                { typeof(SpriteVariable), new VariablePropertyInfo("Sprite", serializedObject.FindProperty("spriteData")) }
+                { typeof(SpriteVariable), new VariablePropertyInfo("Sprite", serializedObject.FindProperty("spriteData")) },
+                { typeof(TextureVariable), new VariablePropertyInfo("Texture", serializedObject.FindProperty("textureData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -49,7 +49,8 @@ namespace Fungus.EditorUtils
                 { typeof(ColorVariable), new VariablePropertyInfo("Color", serializedObject.FindProperty("colorData")) },
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) },
                 { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) },
-                { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) }
+                { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) },
+                { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -44,6 +44,7 @@ namespace Fungus.EditorUtils
                 { typeof(IntegerVariable), new VariablePropertyInfo("Integer", serializedObject.FindProperty("integerData")) },
                 { typeof(FloatVariable), new VariablePropertyInfo("Float", serializedObject.FindProperty("floatData")) },
                 { typeof(StringVariable), new VariablePropertyInfo("String", serializedObject.FindProperty("stringData")) },
+                { typeof(AnimatorVariable), new VariablePropertyInfo("Animator", serializedObject.FindProperty("animatorData")) },
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) }
             };
         }

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -50,7 +50,8 @@ namespace Fungus.EditorUtils
                 { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) },
                 { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) },
                 { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) },
-                { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) }
+                { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) },
+                { typeof(SpriteVariable), new VariablePropertyInfo("Sprite", serializedObject.FindProperty("spriteData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -53,7 +53,9 @@ namespace Fungus.EditorUtils
                 { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) },
                 { typeof(SpriteVariable), new VariablePropertyInfo("Sprite", serializedObject.FindProperty("spriteData")) },
                 { typeof(TextureVariable), new VariablePropertyInfo("Texture", serializedObject.FindProperty("textureData")) },
-                { typeof(TransformVariable), new VariablePropertyInfo("Transform", serializedObject.FindProperty("transformData")) }
+                { typeof(TransformVariable), new VariablePropertyInfo("Transform", serializedObject.FindProperty("transformData")) },
+                { typeof(Vector2Variable), new VariablePropertyInfo("Vector2", serializedObject.FindProperty("vector2Data")) },
+                { typeof(Vector3Variable), new VariablePropertyInfo("Vector3", serializedObject.FindProperty("vector3Data")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -52,7 +52,8 @@ namespace Fungus.EditorUtils
                 { typeof(ObjectVariable), new VariablePropertyInfo("Object", serializedObject.FindProperty("objectData")) },
                 { typeof(Rigidbody2DVariable), new VariablePropertyInfo("Rigidbody2D", serializedObject.FindProperty("rigidbody2DData")) },
                 { typeof(SpriteVariable), new VariablePropertyInfo("Sprite", serializedObject.FindProperty("spriteData")) },
-                { typeof(TextureVariable), new VariablePropertyInfo("Texture", serializedObject.FindProperty("textureData")) }
+                { typeof(TextureVariable), new VariablePropertyInfo("Texture", serializedObject.FindProperty("textureData")) },
+                { typeof(TransformVariable), new VariablePropertyInfo("Transform", serializedObject.FindProperty("transformData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/SetVariableEditor.cs
@@ -47,7 +47,8 @@ namespace Fungus.EditorUtils
                 { typeof(AnimatorVariable), new VariablePropertyInfo("Animator", serializedObject.FindProperty("animatorData")) },
                 { typeof(AudioSourceVariable), new VariablePropertyInfo("AudioSource", serializedObject.FindProperty("audioSourceData")) },
                 { typeof(ColorVariable), new VariablePropertyInfo("Color", serializedObject.FindProperty("colorData")) },
-                { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) }
+                { typeof(GameObjectVariable), new VariablePropertyInfo("GameObject", serializedObject.FindProperty("gameObjectData")) },
+                { typeof(MaterialVariable), new VariablePropertyInfo("Material", serializedObject.FindProperty("materialData")) }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -37,7 +37,8 @@ namespace Fungus.EditorUtils
                 { typeof(ObjectVariable), serializedObject.FindProperty("objectData") },
                 { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") },
                 { typeof(SpriteVariable), serializedObject.FindProperty("spriteData") },
-                { typeof(TextureVariable), serializedObject.FindProperty("textureData") }
+                { typeof(TextureVariable), serializedObject.FindProperty("textureData") },
+                { typeof(TransformVariable), serializedObject.FindProperty("transformData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -38,7 +38,9 @@ namespace Fungus.EditorUtils
                 { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") },
                 { typeof(SpriteVariable), serializedObject.FindProperty("spriteData") },
                 { typeof(TextureVariable), serializedObject.FindProperty("textureData") },
-                { typeof(TransformVariable), serializedObject.FindProperty("transformData") }
+                { typeof(TransformVariable), serializedObject.FindProperty("transformData") },
+                { typeof(Vector2Variable), serializedObject.FindProperty("vector2Data") },
+                { typeof(Vector3Variable), serializedObject.FindProperty("vector3Data") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -34,7 +34,8 @@ namespace Fungus.EditorUtils
                 { typeof(ColorVariable), serializedObject.FindProperty("colorData") },
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") },
                 { typeof(MaterialVariable), serializedObject.FindProperty("materialData") },
-                { typeof(ObjectVariable), serializedObject.FindProperty("objectData") }
+                { typeof(ObjectVariable), serializedObject.FindProperty("objectData") },
+                { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -35,7 +35,8 @@ namespace Fungus.EditorUtils
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") },
                 { typeof(MaterialVariable), serializedObject.FindProperty("materialData") },
                 { typeof(ObjectVariable), serializedObject.FindProperty("objectData") },
-                { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") }
+                { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") },
+                { typeof(SpriteVariable), serializedObject.FindProperty("spriteData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -30,6 +30,7 @@ namespace Fungus.EditorUtils
                 { typeof(FloatVariable), serializedObject.FindProperty("floatData") },
                 { typeof(StringVariable), serializedObject.FindProperty("stringData") },
                 { typeof(AnimatorVariable), serializedObject.FindProperty("animatorData") },
+                { typeof(AudioSourceVariable), serializedObject.FindProperty("audioSourceData") },
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") }
             };
         }

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -29,6 +29,7 @@ namespace Fungus.EditorUtils
                 { typeof(IntegerVariable), serializedObject.FindProperty("integerData") },
                 { typeof(FloatVariable), serializedObject.FindProperty("floatData") },
                 { typeof(StringVariable), serializedObject.FindProperty("stringData") },
+                { typeof(AnimatorVariable), serializedObject.FindProperty("animatorData") },
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") }
             };
         }

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -36,7 +36,8 @@ namespace Fungus.EditorUtils
                 { typeof(MaterialVariable), serializedObject.FindProperty("materialData") },
                 { typeof(ObjectVariable), serializedObject.FindProperty("objectData") },
                 { typeof(Rigidbody2DVariable), serializedObject.FindProperty("rigidbody2DData") },
-                { typeof(SpriteVariable), serializedObject.FindProperty("spriteData") }
+                { typeof(SpriteVariable), serializedObject.FindProperty("spriteData") },
+                { typeof(TextureVariable), serializedObject.FindProperty("textureData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -33,7 +33,8 @@ namespace Fungus.EditorUtils
                 { typeof(AudioSourceVariable), serializedObject.FindProperty("audioSourceData") },
                 { typeof(ColorVariable), serializedObject.FindProperty("colorData") },
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") },
-                { typeof(MaterialVariable), serializedObject.FindProperty("materialData") }
+                { typeof(MaterialVariable), serializedObject.FindProperty("materialData") },
+                { typeof(ObjectVariable), serializedObject.FindProperty("objectData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Fungus.EditorUtils
 {
     [CustomEditor (typeof(VariableCondition), true)]
-    public class VariableConditionEditor : CommandEditor 
+    public class VariableConditionEditor : CommandEditor
     {
         protected SerializedProperty variableProp;
         protected SerializedProperty compareOperatorProp;
@@ -31,6 +31,7 @@ namespace Fungus.EditorUtils
                 { typeof(StringVariable), serializedObject.FindProperty("stringData") },
                 { typeof(AnimatorVariable), serializedObject.FindProperty("animatorData") },
                 { typeof(AudioSourceVariable), serializedObject.FindProperty("audioSourceData") },
+                { typeof(ColorVariable), serializedObject.FindProperty("colorData") },
                 { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") }
             };
         }

--- a/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableConditionEditor.cs
@@ -32,7 +32,8 @@ namespace Fungus.EditorUtils
                 { typeof(AnimatorVariable), serializedObject.FindProperty("animatorData") },
                 { typeof(AudioSourceVariable), serializedObject.FindProperty("audioSourceData") },
                 { typeof(ColorVariable), serializedObject.FindProperty("colorData") },
-                { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") }
+                { typeof(GameObjectVariable), serializedObject.FindProperty("gameObjectData") },
+                { typeof(MaterialVariable), serializedObject.FindProperty("materialData") }
             };
         }
 

--- a/Assets/Fungus/Scripts/VariableTypes/AnimatorVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/AnimatorVariable.cs
@@ -12,7 +12,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class AnimatorVariable : VariableBase<Animator>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Animator value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Animator value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for an Animator variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/AudioSourceVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/AudioSourceVariable.cs
@@ -12,7 +12,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class AudioSourceVariable : VariableBase<AudioSource>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, AudioSource value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, AudioSource value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for an AudioSource variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/BooleanVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/BooleanVariable.cs
@@ -25,13 +25,15 @@ namespace Fungus
             
             switch (compareOperator)
             {
-            case CompareOperator.Equals:
-                condition = lhs == rhs;
-                break;
-            case CompareOperator.NotEquals:
-            default:
-                condition = lhs != rhs;
-                break;
+                case CompareOperator.Equals:
+                    condition = lhs == rhs;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = lhs != rhs;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
             }
             
             return condition;
@@ -41,12 +43,14 @@ namespace Fungus
         {
             switch (setOperator)
             {
-                default:
                 case SetOperator.Assign:
                     Value = value;
                     break;
                 case SetOperator.Negate:
                     Value = !value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
                     break;
             }
         }

--- a/Assets/Fungus/Scripts/VariableTypes/ColorVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/ColorVariable.cs
@@ -13,7 +13,47 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class ColorVariable : VariableBase<Color>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        protected static bool ColorsEqual(Color a, Color b) {
+            return ColorUtility.ToHtmlStringRGBA(a) == ColorUtility.ToHtmlStringRGBA(b);
+        }
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Color value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = ColorsEqual(Value, value);
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = !ColorsEqual(Value, value);
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Color value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Color variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/ColorVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/ColorVariable.cs
@@ -15,7 +15,12 @@ namespace Fungus
     public class ColorVariable : VariableBase<Color>
     {
         public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
-        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+        public static readonly SetOperator[] setOperators = {
+            SetOperator.Assign,
+            SetOperator.Add,
+            SetOperator.Subtract,
+            SetOperator.Multiply
+        };
 
         protected static bool ColorsEqual(Color a, Color b) {
             return ColorUtility.ToHtmlStringRGBA(a) == ColorUtility.ToHtmlStringRGBA(b);
@@ -47,6 +52,15 @@ namespace Fungus
             {
                 case SetOperator.Assign:
                     Value = value;
+                    break;
+                case SetOperator.Add:
+                    Value += value;
+                    break;
+                case SetOperator.Subtract:
+                    Value -= value;
+                    break;
+                case SetOperator.Multiply:
+                    Value *= value;
                     break;
                 default:
                     Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");

--- a/Assets/Fungus/Scripts/VariableTypes/FloatVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/FloatVariable.cs
@@ -38,24 +38,27 @@ namespace Fungus
             
             switch (compareOperator)
             {
-            case CompareOperator.Equals:
-                condition = lhs == rhs;
-                break;
-            case CompareOperator.NotEquals:
-                condition = lhs != rhs;
-                break;
-            case CompareOperator.LessThan:
-                condition = lhs < rhs;
-                break;
-            case CompareOperator.GreaterThan:
-                condition = lhs > rhs;
-                break;
-            case CompareOperator.LessThanOrEquals:
-                condition = lhs <= rhs;
-                break;
-            case CompareOperator.GreaterThanOrEquals:
-                condition = lhs >= rhs;
-                break;
+                case CompareOperator.Equals:
+                    condition = lhs == rhs;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = lhs != rhs;
+                    break;
+                case CompareOperator.LessThan:
+                    condition = lhs < rhs;
+                    break;
+                case CompareOperator.GreaterThan:
+                    condition = lhs > rhs;
+                    break;
+                case CompareOperator.LessThanOrEquals:
+                    condition = lhs <= rhs;
+                    break;
+                case CompareOperator.GreaterThanOrEquals:
+                    condition = lhs >= rhs;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
             }
             
             return condition;
@@ -65,7 +68,6 @@ namespace Fungus
         {
             switch (setOperator)
             {
-                default:
                 case SetOperator.Assign:
                     Value = value;
                     break;
@@ -80,6 +82,9 @@ namespace Fungus
                     break;
                 case SetOperator.Divide:
                     Value /= value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
                     break;
             }
         }

--- a/Assets/Fungus/Scripts/VariableTypes/GameObjectVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/GameObjectVariable.cs
@@ -30,8 +30,10 @@ namespace Fungus
                     condition = lhs == rhs;
                     break;
                 case CompareOperator.NotEquals:
-                default:
                     condition = lhs != rhs;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
                     break;
             }
 
@@ -42,9 +44,11 @@ namespace Fungus
         {
             switch (setOperator)
             {
-                default:
                 case SetOperator.Assign:
                     Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
                     break;
             }
         }

--- a/Assets/Fungus/Scripts/VariableTypes/IntegerVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/IntegerVariable.cs
@@ -38,24 +38,27 @@ namespace Fungus
 
             switch (compareOperator)
             {
-            case CompareOperator.Equals:
-                condition = lhs == rhs;
-                break;
-            case CompareOperator.NotEquals:
-                condition = lhs != rhs;
-                break;
-            case CompareOperator.LessThan:
-                condition = lhs < rhs;
-                break;
-            case CompareOperator.GreaterThan:
-                condition = lhs > rhs;
-                break;
-            case CompareOperator.LessThanOrEquals:
-                condition = lhs <= rhs;
-                break;
-            case CompareOperator.GreaterThanOrEquals:
-                condition = lhs >= rhs;
-                break;
+                case CompareOperator.Equals:
+                    condition = lhs == rhs;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = lhs != rhs;
+                    break;
+                case CompareOperator.LessThan:
+                    condition = lhs < rhs;
+                    break;
+                case CompareOperator.GreaterThan:
+                    condition = lhs > rhs;
+                    break;
+                case CompareOperator.LessThanOrEquals:
+                    condition = lhs <= rhs;
+                    break;
+                case CompareOperator.GreaterThanOrEquals:
+                    condition = lhs >= rhs;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
             }
 
             return condition;
@@ -65,7 +68,6 @@ namespace Fungus
         {
             switch (setOperator)
             {
-                default:
                 case SetOperator.Assign:
                     Value = value;
                     break;
@@ -80,6 +82,9 @@ namespace Fungus
                     break;
                 case SetOperator.Divide:
                     Value /= value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
                     break;
             }
         }

--- a/Assets/Fungus/Scripts/VariableTypes/MaterialVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/MaterialVariable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class MaterialVariable : VariableBase<Material>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Material value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Material value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Material variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/ObjectVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/ObjectVariable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class ObjectVariable : VariableBase<Object>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Object value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Object value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for an Object variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/Rigidbody2DVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Rigidbody2DVariable.cs
@@ -9,7 +9,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class Rigidbody2DVariable : VariableBase<Rigidbody2D>
-    { }
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Rigidbody2D value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Rigidbody2D value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Rigidbody2D variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/SpriteVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/SpriteVariable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class SpriteVariable : VariableBase<Sprite>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Sprite value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Sprite value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Sprite variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/StringVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/StringVariable.cs
@@ -25,13 +25,15 @@ namespace Fungus
 
             switch (compareOperator)
             {
-            case CompareOperator.Equals:
-                condition = lhs == rhs;
-                break;
-            case CompareOperator.NotEquals:
-            default:
-                condition = lhs != rhs;
-                break;
+                case CompareOperator.Equals:
+                    condition = lhs == rhs;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = lhs != rhs;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
             }
 
             return condition;
@@ -41,9 +43,11 @@ namespace Fungus
         {
             switch (setOperator)
             {
-                default:
                 case SetOperator.Assign:
                     Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
                     break;
             }
         }

--- a/Assets/Fungus/Scripts/VariableTypes/TextureVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/TextureVariable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class TextureVariable : VariableBase<Texture>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Texture value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Texture value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Texture variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/TransformVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/TransformVariable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class TransformVariable : VariableBase<Transform>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Transform value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Transform value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Transform variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/Vector2Variable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Vector2Variable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class Vector2Variable : VariableBase<Vector2>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Vector2 value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Vector2 value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Vector2 variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/Vector2Variable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Vector2Variable.cs
@@ -15,7 +15,7 @@ namespace Fungus
     public class Vector2Variable : VariableBase<Vector2>
     {
         public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
-        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign, SetOperator.Add, SetOperator.Subtract };
 
         public virtual bool Evaluate(CompareOperator compareOperator, Vector2 value)
         {
@@ -43,6 +43,12 @@ namespace Fungus
             {
                 case SetOperator.Assign:
                     Value = value;
+                    break;
+                case SetOperator.Add:
+                    Value += value;
+                    break;
+                case SetOperator.Subtract:
+                    Value -= value;
                     break;
                 default:
                     Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");

--- a/Assets/Fungus/Scripts/VariableTypes/Vector3Variable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Vector3Variable.cs
@@ -13,7 +13,43 @@ namespace Fungus
     [AddComponentMenu("")]
     [System.Serializable]
     public class Vector3Variable : VariableBase<Vector3>
-    {}
+    {
+        public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+
+        public virtual bool Evaluate(CompareOperator compareOperator, Vector3 value)
+        {
+            bool condition = false;
+
+            switch (compareOperator)
+            {
+                case CompareOperator.Equals:
+                    condition = Value == value;
+                    break;
+                case CompareOperator.NotEquals:
+                    condition = Value != value;
+                    break;
+                default:
+                    Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");
+                    break;
+            }
+
+            return condition;
+        }
+
+        public override void Apply(SetOperator setOperator, Vector3 value)
+        {
+            switch (setOperator)
+            {
+                case SetOperator.Assign:
+                    Value = value;
+                    break;
+                default:
+                    Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Container for a Vector3 variable reference or constant value.

--- a/Assets/Fungus/Scripts/VariableTypes/Vector3Variable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Vector3Variable.cs
@@ -15,7 +15,7 @@ namespace Fungus
     public class Vector3Variable : VariableBase<Vector3>
     {
         public static readonly CompareOperator[] compareOperators = { CompareOperator.Equals, CompareOperator.NotEquals };
-        public static readonly SetOperator[] setOperators = { SetOperator.Assign };
+        public static readonly SetOperator[] setOperators = { SetOperator.Assign, SetOperator.Add, SetOperator.Subtract };
 
         public virtual bool Evaluate(CompareOperator compareOperator, Vector3 value)
         {
@@ -43,6 +43,12 @@ namespace Fungus
             {
                 case SetOperator.Assign:
                     Value = value;
+                    break;
+                case SetOperator.Add:
+                    Value += value;
+                    break;
+                case SetOperator.Subtract:
+                    Value -= value;
                     break;
                 default:
                     Debug.LogError("The " + setOperator.ToString() + " set operator is not valid.");


### PR DESCRIPTION
This PR adds basic comparison (equals and not equals) as well as basic assign functionality to the following variables:

- Animator
- AudioSource
- Color
- Material
- Object
- Rigidbody2D
- Sprite
- Texture
- Transform
- Vector2
- Vector3

Additionally, Color variables have set functionality for `+=`, `-=` and `*=`. Also, Vector2 and Vector3 variables have set functionality for `+=` and `-=`.