### PR TITLE
Force the hierarchy icon list to refresh when a script a is loaded/ch…

### DIFF
--- a/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
+++ b/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
@@ -25,8 +25,11 @@ namespace Fungus
         //sorted list of the GO instance IDs that have flowcharts on them
         static List<int> flowchartIDs = new List<int>();
 
+        static bool initalHierarchyCheckFlag = true;
+
         static HierarchyIcons()
-        {   
+        {
+            initalHierarchyCheckFlag = true;
             EditorApplication.hierarchyWindowItemOnGUI += HierarchyIconCallback;
             EditorApplication.hierarchyWindowChanged += HierarchyChanged;
         }
@@ -48,6 +51,12 @@ namespace Fungus
         //Draw icon if the isntance id is in our cached list
         static void HierarchyIconCallback(int instanceID, Rect selectionRect)
         {
+            if(initalHierarchyCheckFlag)
+            {
+                HierarchyChanged();
+                initalHierarchyCheckFlag = false;
+            }
+
             if (EditorUtils.FungusEditorPreferences.hideMushroomInHierarchy)
                 return;
 


### PR DESCRIPTION
…anged, fixes delay when icons disappear after a code change is made by no change is made in Unity itself.