### PR TITLE
Conversation options

### DIFF
--- a/Assets/Fungus/Scripts/Commands/Conversation.cs
+++ b/Assets/Fungus/Scripts/Commands/Conversation.cs
@@ -7,11 +7,11 @@ using System.Collections;
 namespace Fungus
 {
     /// <summary>
-    /// Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [: Story text].
+    /// Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [hide] [<<< | >>>] [clear | noclear] [wait | nowait] [fade | nofade] [: Story text].
     /// </summary>
     [CommandInfo("Narrative", 
-                 "Conversation", 
-                 "Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [: Story text]")]
+                 "Conversation",
+                 "Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [hide] [<<< | >>>] [clear | noclear] [wait | nowait] [fade | nofade] [: Story text]")]
     [AddComponentMenu("")]
     [ExecuteInEditMode]
     public class Conversation : Command
@@ -19,6 +19,12 @@ namespace Fungus
         [SerializeField] protected StringDataMulti conversationText;
 
         protected ConversationManager conversationManager = new ConversationManager();
+
+        [SerializeField] protected BooleanData clearPrevious = new BooleanData(true);
+        [SerializeField] protected BooleanData waitForInput = new BooleanData(true);
+        [Tooltip("a wait for seconds added to each item of the conversation.")]
+        [SerializeField] protected FloatData waitForSeconds = new FloatData(0);
+        [SerializeField] protected BooleanData fadeWhenDone = new BooleanData(true);
 
         protected virtual void Start()
         {
@@ -29,6 +35,11 @@ namespace Fungus
         {
             var flowchart = GetFlowchart();
             string subbedText = flowchart.SubstituteVariables(conversationText.Value);
+
+            conversationManager.ClearPrev = clearPrevious;
+            conversationManager.WaitForInput = waitForInput;
+            conversationManager.FadeDone = fadeWhenDone;
+            conversationManager.WaitForSeconds = waitForSeconds;
 
             yield return StartCoroutine(conversationManager.DoConversation(subbedText));
 

--- a/Assets/Fungus/Scripts/Utils/ConversationManager.cs
+++ b/Assets/Fungus/Scripts/Utils/ConversationManager.cs
@@ -23,11 +23,24 @@ namespace Fungus
             public bool Hide { get; set; }
             public FacingDirection FacingDirection { get; set; }
             public bool Flip { get; set; }
+            public bool ClearPrev { get; set; }
+            public bool WaitForInput { get; set; }
+            public bool FadeDone { get; set; }
         }
 
         protected Character[] characters;
 
         protected bool exitSayWait;
+        public bool ClearPrev { get; set; }
+        public bool WaitForInput { get; set; }
+        public bool FadeDone { get; set; }
+
+        public ConversationManager()
+        {
+            ClearPrev = true;
+            FadeDone = true;
+            WaitForInput = true;
+        }
 
         /// <summary>
         /// Splits the string passed in by the delimiters passed in.
@@ -147,6 +160,9 @@ namespace Fungus
         protected virtual ConversationItem CreateConversationItem(string[] sayParams, string text, Character currentCharacter)
         {
             var item = new ConversationItem();
+            item.ClearPrev = ClearPrev;
+            item.FadeDone = FadeDone;
+            item.WaitForInput = WaitForInput;
 
             // Populate the story text to be written
             item.Text = text;
@@ -155,6 +171,35 @@ namespace Fungus
             {
                 // Text only, no params - early out.
                 return item;
+            }
+
+            //TODO this needs a refactor
+            for (int i = 0; i < sayParams.Length; i++)
+            {
+                if (string.Compare(sayParams[i], "clear", true) == 0)
+                {
+                    item.ClearPrev = true;
+                }
+                else if (string.Compare(sayParams[i], "noclear", true) == 0)
+                {
+                    item.ClearPrev = false;
+                }
+                else if (string.Compare(sayParams[i], "fade", true) == 0)
+                {
+                    item.FadeDone = true;
+                }
+                else if (string.Compare(sayParams[i], "nofade", true) == 0)
+                {
+                    item.FadeDone = false;
+                }
+                else if (string.Compare(sayParams[i], "wait", true) == 0)
+                {
+                    item.WaitForInput = true;
+                }
+                else if (string.Compare(sayParams[i], "nowait", true) == 0)
+                {
+                    item.WaitForInput = false;
+                }
             }
 
             // try to find the character param first, since we need to get its portrait
@@ -380,7 +425,7 @@ namespace Fungus
 
                 if (!string.IsNullOrEmpty(item.Text)) { 
                     exitSayWait = false;
-                    sayDialog.Say(item.Text, true, true, true, true, false, null, () => {
+                    sayDialog.Say(item.Text, item.ClearPrev, item.WaitForInput, item.FadeDone, true, false, null, () => {
                         exitSayWait = true;
                     });
 

--- a/Assets/Fungus/Scripts/Utils/ConversationManager.cs
+++ b/Assets/Fungus/Scripts/Utils/ConversationManager.cs
@@ -34,6 +34,7 @@ namespace Fungus
         public bool ClearPrev { get; set; }
         public bool WaitForInput { get; set; }
         public bool FadeDone { get; set; }
+        public FloatData WaitForSeconds { get; internal set; }
 
         public ConversationManager()
         {
@@ -166,6 +167,11 @@ namespace Fungus
 
             // Populate the story text to be written
             item.Text = text;
+
+            if(WaitForSeconds > 0)
+            {
+                item.Text += "{w=" + WaitForSeconds.ToString() +"}";
+            }
 
             if (sayParams == null || sayParams.Length == 0)
             {

--- a/Assets/Fungus/Scripts/Utils/TextTagParser.cs
+++ b/Assets/Fungus/Scripts/Utils/TextTagParser.cs
@@ -209,6 +209,7 @@ namespace Fungus
                 "\t{w}, {w=0.5} Wait (seconds)\n" +
                 "\t{wi} Wait for input\n" +
                 "\t{wc} Wait for input and clear\n" +
+                "\t{wvo} Wait for voice over line to complete\n" +
                 "\t{wp}, {wp=0.5} Wait on punctuation (seconds){/wp}\n" +
                 "\t{c} Clear\n" +
                 "\t{x} Exit, advance to the next command without waiting for input\n" +

--- a/Assets/FungusExamples/Conversation/Conversation.unity
+++ b/Assets/FungusExamples/Conversation/Conversation.unity
@@ -1,19 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-SceneSettings:
+OcclusionCullingSettings:
   m_ObjectHideFlags: 0
-  m_PVSData: 
-  m_PVSObjectsArray: []
-  m_PVSPortalsArray: []
+  serializedVersion: 2
   m_OcclusionBakeSettings:
     smallestOccluder: 5
     smallestHole: 0.25
     backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -41,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 11
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,40 +67,62 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
+    agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
-    accuratePlacement: 0
     minRegionArea: 2
-    cellSize: 0.16666667
     manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &205269089
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110280, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 205269090}
-  - 222: {fileID: 205269092}
-  - 114: {fileID: 205269091}
+  - component: {fileID: 205269090}
+  - component: {fileID: 205269092}
+  - component: {fileID: 205269091}
   m_Layer: 0
   m_Name: Offscreen Right
   m_TagString: Untagged
@@ -117,10 +140,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1544660787}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 1300, y: -1000}
@@ -166,10 +189,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 100000, guid: b20518d45890e4be59ba82946f88026c, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 275029864}
-  - 114: {fileID: 275029863}
+  - component: {fileID: 275029864}
+  - component: {fileID: 275029863}
   m_Layer: 0
   m_Name: John
   m_TagString: Untagged
@@ -192,7 +215,6 @@ MonoBehaviour:
   nameText: John
   nameColor: {r: 1, g: 1, b: 1, a: 1}
   soundEffect: {fileID: 0}
-  profileSprite: {fileID: 21300000, guid: 58bfb145092302e4083ef8a9e4eeb576, type: 3}
   portraits:
   - {fileID: 21300000, guid: 58bfb145092302e4083ef8a9e4eeb576, type: 3}
   - {fileID: 21300000, guid: 820bab66bb5a044ec961ba8ee3b045cc, type: 3}
@@ -208,20 +230,20 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &534534503
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110270, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 534534504}
-  - 222: {fileID: 534534506}
-  - 114: {fileID: 534534505}
+  - component: {fileID: 534534504}
+  - component: {fileID: 534534506}
+  - component: {fileID: 534534505}
   m_Layer: 0
   m_Name: Right
   m_TagString: Untagged
@@ -239,10 +261,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1544660787}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 460.43, y: -1000}
@@ -288,11 +310,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110282, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 599196445}
-  - 222: {fileID: 599196447}
-  - 114: {fileID: 599196446}
+  - component: {fileID: 599196445}
+  - component: {fileID: 599196447}
+  - component: {fileID: 599196446}
   m_Layer: 0
   m_Name: Left
   m_TagString: Untagged
@@ -310,10 +332,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1544660787}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: -460.43, y: -1000}
@@ -359,11 +381,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110272, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1085130772}
-  - 222: {fileID: 1085130774}
-  - 114: {fileID: 1085130773}
+  - component: {fileID: 1085130772}
+  - component: {fileID: 1085130774}
+  - component: {fileID: 1085130773}
   m_Layer: 0
   m_Name: Offscreen Left
   m_TagString: Untagged
@@ -381,10 +403,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1544660787}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: -1300, y: -1000}
@@ -430,10 +452,10 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1226317643}
-  - 114: {fileID: 1226317642}
+  - component: {fileID: 1226317643}
+  - component: {fileID: 1226317642}
   m_Layer: 0
   m_Name: _FungusState
   m_TagString: Untagged
@@ -462,21 +484,21 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1290383786
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1290383790}
-  - 114: {fileID: 1290383789}
-  - 114: {fileID: 1290383788}
-  - 114: {fileID: 1290383787}
+  - component: {fileID: 1290383790}
+  - component: {fileID: 1290383789}
+  - component: {fileID: 1290383788}
+  - component: {fileID: 1290383787}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -537,20 +559,20 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 179.999, y: 179.999, z: 179.999}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 179.999, y: 179.999, z: 179.999}
 --- !u!1 &1311069593
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110278, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1311069594}
-  - 222: {fileID: 1311069595}
-  - 114: {fileID: 1311069596}
+  - component: {fileID: 1311069594}
+  - component: {fileID: 1311069595}
+  - component: {fileID: 1311069596}
   m_Layer: 0
   m_Name: Middle
   m_TagString: Untagged
@@ -568,10 +590,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1544660787}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: -1000}
@@ -617,13 +639,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110276, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1544660787}
-  - 223: {fileID: 1544660791}
-  - 114: {fileID: 1544660790}
-  - 114: {fileID: 1544660789}
-  - 225: {fileID: 1544660788}
+  - component: {fileID: 1544660787}
+  - component: {fileID: 1544660791}
+  - component: {fileID: 1544660790}
+  - component: {fileID: 1544660789}
+  - component: {fileID: 1544660788}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -641,7 +663,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1311069594}
   - {fileID: 599196445}
@@ -650,6 +671,7 @@ RectTransform:
   - {fileID: 205269090}
   m_Father: {fileID: 2073331544}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -714,7 +736,7 @@ Canvas:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1544660786}
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
@@ -723,6 +745,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -731,13 +754,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1726345443}
-  - 20: {fileID: 1726345442}
-  - 92: {fileID: 1726345441}
-  - 124: {fileID: 1726345440}
-  - 81: {fileID: 1726345439}
+  - component: {fileID: 1726345443}
+  - component: {fileID: 1726345442}
+  - component: {fileID: 1726345441}
+  - component: {fileID: 1726345440}
+  - component: {fileID: 1726345439}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -796,10 +819,12 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!4 &1726345443
 Transform:
   m_ObjectHideFlags: 0
@@ -809,19 +834,19 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1745642867
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 100000, guid: b20518d45890e4be59ba82946f88026c, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1745642869}
-  - 114: {fileID: 1745642868}
+  - component: {fileID: 1745642869}
+  - component: {fileID: 1745642868}
   m_Layer: 0
   m_Name: Sherlock
   m_TagString: Untagged
@@ -844,7 +869,6 @@ MonoBehaviour:
   nameText: Sherlock
   nameColor: {r: 1, g: 1, b: 1, a: 1}
   soundEffect: {fileID: 0}
-  profileSprite: {fileID: 21300000, guid: b9482ea03e69b5a4aa5e7827da354549, type: 3}
   portraits:
   - {fileID: 21300000, guid: b9482ea03e69b5a4aa5e7827da354549, type: 3}
   - {fileID: 21300000, guid: 7497fd82318972540af8666a234a9685, type: 3}
@@ -860,25 +884,25 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1755499605
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 142980, guid: 5e7fbc8d4eb714b279eeeef2262c1e1a, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1755499610}
-  - 114: {fileID: 1755499606}
-  - 114: {fileID: 1755499608}
-  - 114: {fileID: 1755499609}
-  - 114: {fileID: 1755499607}
-  - 114: {fileID: 1755499611}
-  - 114: {fileID: 1755499613}
-  - 114: {fileID: 1755499612}
+  - component: {fileID: 1755499610}
+  - component: {fileID: 1755499606}
+  - component: {fileID: 1755499608}
+  - component: {fileID: 1755499609}
+  - component: {fileID: 1755499607}
+  - component: {fileID: 1755499611}
+  - component: {fileID: 1755499613}
+  - component: {fileID: 1755499612}
   m_Layer: 0
   m_Name: Flowchart
   m_TagString: Untagged
@@ -910,9 +934,8 @@ MonoBehaviour:
     y: -340
     width: 1114
     height: 859
-  selectedBlock: {fileID: 1755499608}
-  selectedCommands:
-  - {fileID: 1755499611}
+  selectedBlocks: []
+  selectedCommands: []
   variables: []
   description: 
   stepPause: 0
@@ -936,13 +959,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   itemId: 1
-  errorMessage: 
   indentLevel: 0
   conversationText:
     stringRef: {fileID: 0}
     stringVal: 'john bored left: Oh, so that''s how you use the Conversation command.
 
-      sherlock eyeroll right: Yes, well done John.
+      sherlock eyeroll right nowait: Yes, well done John. {w=1.5}
 
       You catch on quickly don''t you?
 
@@ -954,13 +976,27 @@ MonoBehaviour:
       -- This is a comment, it doesn''t appear in the conversation
 
 
-      john angry middle: Wait, what!
+      john angry left nowait: Wait {w=0.6}
 
-      left: There''s no need to be rude Sherlock!
+      middle noclear:, what!
+
+      left nofade: There''s no need to be rude Sherlock!
 
       bored: Not like that would stop you.
 
 '
+  clearPrevious:
+    booleanRef: {fileID: 0}
+    booleanVal: 1
+  waitForInput:
+    booleanRef: {fileID: 0}
+    booleanVal: 1
+  waitForSeconds:
+    floatRef: {fileID: 0}
+    floatVal: 0
+  fadeWhenDone:
+    booleanRef: {fileID: 0}
+    booleanVal: 1
 --- !u!114 &1755499608
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -979,6 +1015,8 @@ MonoBehaviour:
     y: 70
     width: 120
     height: 40
+  tint: {r: 1, g: 1, b: 1, a: 1}
+  useCustomTint: 0
   itemId: 0
   blockName: Start
   description: 
@@ -1001,6 +1039,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentBlock: {fileID: 1755499608}
+  waitForFrames: 1
 --- !u!4 &1755499610
 Transform:
   m_ObjectHideFlags: 0
@@ -1010,10 +1049,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1755499611
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -1026,7 +1065,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   itemId: 2
-  errorMessage: 
   indentLevel: 0
   luaEnvironment: {fileID: 0}
   luaFile: {fileID: 0}
@@ -1064,7 +1102,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   itemId: 4
-  errorMessage: 
   indentLevel: 0
   commenterName: 
   commentText: Example using Conversation function in Lua
@@ -1080,7 +1117,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   itemId: 3
-  errorMessage: 
   indentLevel: 0
   commenterName: 
   commentText: Example using Conversation Command
@@ -1089,10 +1125,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 110274, guid: c6289d5f8fa843145a2355af9cb09719, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 2073331544}
-  - 114: {fileID: 2073331543}
+  - component: {fileID: 2073331544}
+  - component: {fileID: 2073331543}
   m_Layer: 0
   m_Name: Stage
   m_TagString: Untagged
@@ -1114,10 +1150,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   portraitCanvas: {fileID: 1544660791}
   dimPortraits: 1
+  dimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   fadeDuration: 0.75
   moveDuration: 1
   fadeEaseType: 4
-  moveEaseType: 4
   shiftOffset: {x: 0, y: 0}
   defaultPosition: {fileID: 1311069596}
   positions:
@@ -1126,13 +1162,6 @@ MonoBehaviour:
   - {fileID: 534534504}
   - {fileID: 1085130772}
   - {fileID: 205269090}
-  cachedPositions:
-  - {fileID: 599196445}
-  - {fileID: 1311069594}
-  - {fileID: 534534504}
-  - {fileID: 1085130772}
-  - {fileID: 205269090}
-  charactersOnStage: []
 --- !u!4 &2073331544
 Transform:
   m_ObjectHideFlags: 0
@@ -1142,8 +1171,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1544660787}
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/FungusExamples/Conversation/Conversation.unity
+++ b/Assets/FungusExamples/Conversation/Conversation.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,6 +39,7 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -54,11 +55,10 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 9
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 40
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 0
@@ -934,8 +934,10 @@ MonoBehaviour:
     y: -340
     width: 1114
     height: 859
-  selectedBlocks: []
-  selectedCommands: []
+  selectedBlocks:
+  - {fileID: 1755499608}
+  selectedCommands:
+  - {fileID: 1755499607}
   variables: []
   description: 
   stepPause: 0

--- a/Docs/command_ref/narrative_commands.md
+++ b/Docs/command_ref/narrative_commands.md
@@ -25,9 +25,14 @@ Wait Until Finished | System.Boolean | Wait until the tween has finished before 
 Display | Fungus.StageDisplayType | Display type
 
 # Conversation # {#Conversation}
-Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [: Story text]
+Do multiple say and portrait commands in a single block of text. Format is: [character] [portrait] [stage position] [hide] [<<< | >>>] [clear | noclear] [wait | nowait] [fade | nofade] [: Story text]
 
 Defined in Fungus.Conversation
+
+Property | Type | Description
+ --- | --- | ---
+Wait For Seconds | Fungus.FloatData | a wait for seconds added to each item of the conversation.
+
 # Menu # {#Menu}
 Displays a button in a multiple choice menu
 

--- a/Docs/fungus_docs/conversation_system.md
+++ b/Docs/fungus_docs/conversation_system.md
@@ -38,7 +38,7 @@ sherlock hide:
 
 The format for conversation text is:
 ```text
-[character] [portrait] [position] [hide] [<<< | >>>]: [Dialogue text]
+[character] [portrait] [position] [hide] [<<< | >>>] [clear | noclear] [wait | nowait] [fade | nofade]: [Dialogue text]
 ```
 
 - character: The gameobject name or Name Text value of the speaking character.
@@ -47,6 +47,9 @@ The format for conversation text is:
 - hide: Hides the character
 - <<<: Portrait face left
 - >>>: Portrait face right
+- clear | noclear: override the ClearPreviousLine default with true on clear or with false with noclear
+- wait | nowait: override the WaitForInput default with true on wait or with false with nowait
+- fade | nofade: override the FadeDone default with true on fade or with false with nofade. This is rarely required as it only really makes a difference on the last say of the conversation anyway.
 
 Parameters go on the left of the colon and the dialogue text goes on the right. You can omit any parameter and specify them in any order. Parameters are separated by spaces. If you need to use a name which contains spaces, wrap it in quotation marks e.g. "John Watson". Parameters are case insensitive. Blank lines and comment lines starting with -- are ignored. A line of dialogue text on its own will be spoken by the most recent character. You can omit dialogue text, but remember you still need to add the : character at the end of the line.
 


### PR DESCRIPTION
Follow up from [the forum](http://fungusgames.com/forum#!/general:extending-the-conversation)
Allows a Conversation to control a similar set of options as a Say command.
-On the conversation command itself you can set defaults for fade, wait for input, wait delay, extend previous
-Each item in the conversation can now also set [clear | noclear] [wait | nowait] [fade | nofade] before the story text