### PR TITLE
Fixed stray \\ that were not being stripped on Mac OS, when importing…

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FungusEditorResources.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorResources.cs
@@ -78,7 +78,7 @@ namespace Fungus.EditorUtils
 
         private static FungusEditorResources instance;
         private static readonly string editorResourcesFolderName = "\"EditorResources\"";
-        private static readonly string PartialEditorResourcesPath = System.IO.Path.Combine("Fungus\\", "EditorResources");
+        private static readonly string PartialEditorResourcesPath = System.IO.Path.Combine("Fungus", "EditorResources");
         [SerializeField] [HideInInspector] private bool updateOnReloadScripts = false;
 
         internal static FungusEditorResources Instance


### PR DESCRIPTION
… a fresh. Resulted in incomplete generation of editor resources.

Reported on the [forum](http://fungusgames.com/forum#!/general:creat-flowchart-failed). 