### PR TITLE
NarrativeLog is tolerant of null Name or Story fields

### DIFF
--- a/Assets/Fungus/Scripts/Components/NarrativeLog.cs
+++ b/Assets/Fungus/Scripts/Components/NarrativeLog.cs
@@ -66,8 +66,11 @@ namespace Fungus
         {
             if (writerState == WriterState.End)
             {
-                AddLine(SayDialog.GetSayDialog().NameText.text,
-                    SayDialog.GetSayDialog().StoryText.text);
+                var sd = SayDialog.GetSayDialog();
+                var from = sd.NameText != null ? sd.NameText.text : string.Empty;
+                var line = sd.StoryText != null ? sd.StoryText.text : string.Empty;
+
+                AddLine(from, line);
             }
         }
 


### PR DESCRIPTION
-previously caused nullref in TheFacility Demo Scene