### PR TITLE
Conversation Manager Regex now allows - and _ within say params group.

### DIFF
--- a/Assets/Fungus/Scripts/Utils/ConversationManager.cs
+++ b/Assets/Fungus/Scripts/Utils/ConversationManager.cs
@@ -116,7 +116,7 @@ namespace Fungus
         {
             //find SimpleScript say strings with portrait options
             //You can test regex matches here: http://regexstorm.net/tester
-            var sayRegex = new Regex(@"((?<sayParams>[\w ""><.']*):)?(?<text>.*)\r*(\n|$)");
+            var sayRegex = new Regex(@"((?<sayParams>[\w ""><.'-_]*):)?(?<text>.*)\r*(\n|$)");
             MatchCollection sayMatches = sayRegex.Matches(conv);
 
             var items = new List<ConversationItem>(sayMatches.Count);


### PR DESCRIPTION
-Allows conversation to use portraits like calling-neutral