### PR TITLE
ElseIfs now confirm that the previous condition was at the same indent as themselves.

### DIFF
--- a/Assets/Fungus/Scripts/Commands/Condition.cs
+++ b/Assets/Fungus/Scripts/Commands/Condition.cs
@@ -59,8 +59,11 @@ namespace Fungus
             else
             {
                 System.Type previousCommandType = ParentBlock.GetPreviousActiveCommandType();
+                var prevCmdIndent = ParentBlock.GetPreviousActiveCommandIndent();
 
-                if (previousCommandType.IsSubclassOf(typeof(Condition)))
+                //handle our matching if or else if in the chain failing and moving to us,
+                //  need to make sure it is the same indent level
+                if (prevCmdIndent == IndentLevel && previousCommandType.IsSubclassOf(typeof(Condition)))
                 {
                     // Else If behaves the same as an If command
                     EvaluateAndContinue();

--- a/Assets/Fungus/Scripts/Components/Block.cs
+++ b/Assets/Fungus/Scripts/Components/Block.cs
@@ -355,6 +355,17 @@ namespace Fungus
             return null;
         }
 
+        public virtual int GetPreviousActiveCommandIndent()
+        {
+            if (previousActiveCommandIndex >= 0 &&
+                previousActiveCommandIndex < commandList.Count)
+            {
+                return commandList[previousActiveCommandIndex].IndentLevel;
+            }
+
+            return -1;
+        }
+
         /// <summary>
         /// Recalculate the indent levels for all commands in the list.
         /// </summary>


### PR DESCRIPTION
-Corrects elifs from pairing incorrectly with nested ifs prior to themselves
-Thanks to Wolfrug on the forum http://fungusgames.com/forum#!/support-questions:if-else-bug