### PR TITLE
Change FlowchartMenuItem.SpawnPrefab to GameObject.Inst rather than P…

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FlowchartMenuItems.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartMenuItems.cs
@@ -58,8 +58,8 @@ namespace Fungus.EditorUtils
                 return null;
             }
 
-            GameObject go = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
-            PrefabUtility.DisconnectPrefabInstance(go);
+            GameObject go = GameObject.Instantiate(prefab) as GameObject;
+            go.name = prefab.name;
 
             SceneView view = SceneView.lastActiveSceneView;
             if (view != null)


### PR DESCRIPTION
…refabUtil to avoid exception modifications.empty

Avoids or allows Unity to internally deal with the assertion that arrise from PrefabUtil when passing a prefab with UI elements. Change is not a concern here as in this case we are intentionally removing the prefab link that would be able to be maintained by the PrefabUtil.