### PR TITLE
TMPro support for Get/Set Text, FadeUI & NarrativeLog

### DIFF
--- a/Assets/Fungus/Scripts/Commands/FadeUI.cs
+++ b/Assets/Fungus/Scripts/Commands/FadeUI.cs
@@ -128,6 +128,83 @@ namespace Fungus
                     }
                 }
             }
+
+#if UNITY_2018_1_OR_NEWER
+            var tmpros = go.GetComponentsInChildren<TMPro.TMP_Text>();
+            for (int i = 0; i < tmpros.Length; i++)
+            {
+            
+                var tmpro = tmpros[i];
+                if (Mathf.Approximately(duration, 0f))
+                {
+                    switch (fadeMode)
+                    {
+                    case FadeMode.Alpha:
+                        Color tempColor = tmpro.color;
+                        tempColor.a = targetAlpha;
+                        tmpro.color = tempColor;
+                        break;
+                    case FadeMode.Color:
+                        tmpro.color = targetColor;
+                        break;
+                    }
+                }
+                else
+                {
+                    switch (fadeMode)
+                    {
+                    case FadeMode.Alpha:
+                        LeanTween.value(tmpro.gameObject, tmpro.color.a, targetAlpha.Value, duration)
+                                 .setEase(tweenType)
+                                 .setOnUpdate((float alphaValue) =>
+                                 {
+                                     Color tempColor = tmpro.color;
+                                     tempColor.a = alphaValue;
+                                     tmpro.color = tempColor;
+                                 });
+                        break;
+                    case FadeMode.Color:
+                        LeanTween.value(tmpro.gameObject, tmpro.color, targetColor.Value, duration)
+                                 .setEase(tweenType)
+                                 .setOnUpdate((Color colorValue) =>
+                                 {
+                                     tmpro.color = colorValue;
+                                 });
+                        break;
+                    }
+                }
+            }
+#endif
+            //canvas groups don't support color but we can anim the alpha IN the color
+            var canvasGroups = go.GetComponentsInChildren<CanvasGroup>();
+            for (int i = 0; i < canvasGroups.Length; i++)
+            {
+                var canvasGroup = canvasGroups[i];
+                if (Mathf.Approximately(duration, 0f))
+                {
+                    switch (fadeMode)
+                    {
+                        case FadeMode.Alpha:
+                            canvasGroup.alpha = targetAlpha.Value;
+                            break;
+                        case FadeMode.Color:
+                            canvasGroup.alpha = targetColor.Value.a;
+                        break;
+                    }
+                }
+                else
+                {
+                    switch (fadeMode)
+                    {
+                        case FadeMode.Alpha:
+                            LeanTween.alphaCanvas(canvasGroup, targetAlpha, duration).setEase(tweenType);
+                            break;
+                        case FadeMode.Color:
+                            LeanTween.alphaCanvas(canvasGroup, targetColor.Value.a, duration).setEase(tweenType);
+                        break;
+                    }
+                }
+            }
         }
 
         protected override string GetSummaryValue()
@@ -144,7 +221,7 @@ namespace Fungus
             return "";
         }
 
-        #region Public members
+#region Public members
 
         public override bool IsPropertyVisible(string propertyName)
         {
@@ -163,6 +240,6 @@ namespace Fungus
             return true;
         }
 
-        #endregion
+#endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/GetText.cs
+++ b/Assets/Fungus/Scripts/Commands/GetText.cs
@@ -32,33 +32,15 @@ namespace Fungus
                 Continue();
                 return;
             }
-            
-            if (targetTextObject != null)
+
+            TextAdapter textAdapter = new TextAdapter();
+            textAdapter.InitFromGameObject(targetTextObject);
+
+            if (textAdapter.HasTextObject())
             {
-                // Use first component found of Text, Input Field or Text Mesh type
-                Text uiText = targetTextObject.GetComponent<Text>();
-                if (uiText != null)
-                {
-                    stringVariable.Value = uiText.text;
-                }
-                else
-                {
-                    InputField inputField = targetTextObject.GetComponent<InputField>();
-                    if (inputField != null)
-                    {
-                        stringVariable.Value = inputField.text;
-                    }
-                    else
-                    {
-                        TextMesh textMesh = targetTextObject.GetComponent<TextMesh>();
-                        if (textMesh != null)
-                        {
-                            stringVariable.Value = textMesh.text;
-                        }
-                    }
-                }
+                stringVariable.Value = textAdapter.Text;
             }
-            
+
             Continue();
         }
         

--- a/Assets/Fungus/Scripts/Commands/SetText.cs
+++ b/Assets/Fungus/Scripts/Commands/SetText.cs
@@ -38,30 +38,15 @@ namespace Fungus
                 Continue();
                 return;
             }
-            
-            // Use first component found of Text, Input Field or Text Mesh type
-            Text uiText = targetTextObject.GetComponent<Text>();
-            if (uiText != null)
+
+            TextAdapter textAdapter = new TextAdapter();
+            textAdapter.InitFromGameObject(targetTextObject);
+
+            if (textAdapter.HasTextObject())
             {
-                uiText.text = newText;
+                textAdapter.Text = newText;
             }
-            else
-            {
-                InputField inputField = targetTextObject.GetComponent<InputField>();
-                if (inputField != null)
-                {
-                    inputField.text = newText;
-                }
-                else
-                {
-                    TextMesh textMesh = targetTextObject.GetComponent<TextMesh>();
-                    if (textMesh != null)
-                    {
-                        textMesh.text = newText;
-                    }
-                }
-            }
-            
+
             Continue();
         }
         

--- a/Assets/Fungus/Scripts/Components/NarrativeLogMenu.cs
+++ b/Assets/Fungus/Scripts/Components/NarrativeLogMenu.cs
@@ -22,6 +22,8 @@ namespace Fungus
 
         [Tooltip("A scrollable text field used for displaying conversation history.")]
         [SerializeField] protected ScrollRect narrativeLogView;
+
+        protected TextAdapter narLogViewtextAdapter = new TextAdapter();
         
         [Tooltip("The CanvasGroup containing the save menu buttons")]
         [SerializeField] protected CanvasGroup narrativeLogMenuGroup;
@@ -57,6 +59,8 @@ namespace Fungus
                 logView.SetActive(false);
                 this.enabled = false;
             }
+
+            narLogViewtextAdapter.InitFromGameObject(narrativeLogView.gameObject, true);
         }
 
         protected virtual void Start()
@@ -126,11 +130,8 @@ namespace Fungus
         {
             if (narrativeLogView.enabled)
             {
-                var historyText = narrativeLogView.GetComponentInChildren<Text>();
-                if (historyText != null)
-                {
-                    historyText.text = FungusManager.Instance.NarrativeLog.GetPrettyHistory();
-                }
+                narLogViewtextAdapter.Text = FungusManager.Instance.NarrativeLog.GetPrettyHistory();
+                
                 Canvas.ForceUpdateCanvases();
                 narrativeLogView.verticalNormalizedPosition = 0f;
                 Canvas.ForceUpdateCanvases();

--- a/Assets/Fungus/Scripts/Utils/TextAdapter.cs
+++ b/Assets/Fungus/Scripts/Utils/TextAdapter.cs
@@ -12,6 +12,9 @@ namespace Fungus
         protected Text textUI;
         protected InputField inputField;
         protected TextMesh textMesh;
+#if UNITY_2018_1_OR_NEWER
+        protected TMPro.TMP_Text tmpro;
+#endif
         protected Component textComponent;
         protected PropertyInfo textProperty;
         protected IWriterTextDestination writerTextDestination;
@@ -28,6 +31,9 @@ namespace Fungus
                 textUI = go.GetComponent<Text>();
                 inputField = go.GetComponent<InputField>();
                 textMesh = go.GetComponent<TextMesh>();
+#if UNITY_2018_1_OR_NEWER
+                tmpro = go.GetComponent<TMPro.TMP_Text>();
+#endif
                 writerTextDestination = go.GetComponent<IWriterTextDestination>();
             }
             else
@@ -35,6 +41,9 @@ namespace Fungus
                 textUI = go.GetComponentInChildren<Text>();
                 inputField = go.GetComponentInChildren<InputField>();
                 textMesh = go.GetComponentInChildren<TextMesh>();
+#if UNITY_2018_1_OR_NEWER
+                tmpro = go.GetComponentInChildren<TMPro.TMP_Text>();
+#endif
                 writerTextDestination = go.GetComponentInChildren<IWriterTextDestination>();
             }
             
@@ -74,7 +83,14 @@ namespace Fungus
                 textMesh.richText = true;
             }
 
-            if(writerTextDestination != null)
+#if UNITY_2018_1_OR_NEWER
+            if(tmpro != null)
+            {
+                tmpro.richText = true;
+            }
+#endif
+
+            if (writerTextDestination != null)
             {
                 writerTextDestination.ForceRichText();
             }
@@ -97,6 +113,12 @@ namespace Fungus
             {
                 textMesh.color = textColor;
             }
+#if UNITY_2018_1_OR_NEWER
+            else if (tmpro != null)
+            {
+                tmpro.color = textColor;
+            }
+#endif
             else if (writerTextDestination != null)
             {
                 writerTextDestination.SetTextColor(textColor);
@@ -126,6 +148,12 @@ namespace Fungus
                 tempColor.a = textAlpha;
                 textMesh.color = tempColor;
             }
+#if UNITY_2018_1_OR_NEWER
+            else if (tmpro != null)
+            {
+                tmpro.alpha = textAlpha;
+            }
+#endif
             else if (writerTextDestination != null)
             {
                 writerTextDestination.SetTextAlpha(textAlpha);
@@ -134,7 +162,11 @@ namespace Fungus
 
         public bool HasTextObject()
         {
-            return (textUI != null || inputField != null || textMesh != null || textComponent != null || writerTextDestination != null);
+            return (textUI != null || inputField != null || textMesh != null || textComponent != null ||
+#if UNITY_2018_1_OR_NEWER
+                tmpro !=null ||
+#endif
+                 writerTextDestination != null);
         }
 
         public bool SupportsRichText()
@@ -151,6 +183,12 @@ namespace Fungus
             {
                 return textMesh.richText;
             }
+#if UNITY_2018_1_OR_NEWER
+            if (tmpro != null)
+            {
+                return true;
+            }
+#endif
             if (writerTextDestination != null)
             {
                 return writerTextDestination.SupportsRichText();
@@ -178,6 +216,12 @@ namespace Fungus
                 {
                     return textMesh.text;
                 }
+#if UNITY_2018_1_OR_NEWER
+                else if (tmpro != null)
+                {
+                    return tmpro.text;
+                }
+#endif
                 else if (textProperty != null)
                 {
                     return textProperty.GetValue(textComponent, null) as string;
@@ -204,6 +248,12 @@ namespace Fungus
                 {
                     textMesh.text = value;
                 }
+#if UNITY_2018_1_OR_NEWER
+                else if (tmpro != null)
+                {
+                    tmpro.text = value;
+                }
+#endif
                 else if (textProperty != null)
                 {
                     textProperty.SetValue(textComponent, value, null);


### PR DESCRIPTION
Based on feedback from linkad333 on the forum, [link](http://fungusgames.com/forum#!/general:text-mesh-pro-w-fungus-fun). 

-Support use of TMPro in Set Text, Get Text and Narrative Log Menu via use of TextAdapter
-FadeUI also checks for CanvasGroups and if 2018_1_OR_NEWER will check for TMP_Text components too
-TextAdapter uses 2018_1_OR_NEWER for more thorough support of TMPro such as color and rich text operations