### PR TITLE
VariableEditor popup name and key concat no longer has spaces, allows…

### DIFF
--- a/Assets/Fungus/Scripts/Editor/VariableEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableEditor.cs
@@ -107,7 +107,7 @@ namespace Fungus.EditorUtils
                         }
                     }
 
-                    variableKeys.Add(fs.name + " / " + v.Key);
+                    variableKeys.Add(fs.name + "/" + v.Key);
                     variableObjects.Add(v);
 
                     index++;


### PR DESCRIPTION
… the PopUp to correctly nest items with the same parent

Reported on the forum, [link](http://fungusgames.com/forum#!/fungus-development:did-this-break-fungus-eas).

Without fix;
![image](https://user-images.githubusercontent.com/4897812/50893170-01190e00-144c-11e9-8fd4-efe111df9b9f.png)

With fix;
![image](https://user-images.githubusercontent.com/4897812/50893191-0b3b0c80-144c-11e9-941b-f74f4a256548.png)
