### PR TITLE
Command has reference and summary updates

### DIFF
--- a/Assets/Fungus/Scripts/Commands/Call.cs
+++ b/Assets/Fungus/Scripts/Commands/Call.cs
@@ -161,6 +161,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return startLabel.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/ControlAudio.cs
+++ b/Assets/Fungus/Scripts/Commands/ControlAudio.cs
@@ -284,6 +284,11 @@ namespace Fungus
             return new Color32(242, 209, 176, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _audioSource.audioSourceRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/Conversation.cs
+++ b/Assets/Fungus/Scripts/Commands/Conversation.cs
@@ -64,5 +64,19 @@ namespace Fungus
         }
 
         #endregion
+
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(conversationText, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Conversation.cs
+++ b/Assets/Fungus/Scripts/Commands/Conversation.cs
@@ -63,6 +63,13 @@ namespace Fungus
             return new Color32(184, 210, 235, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return clearPrevious.booleanRef == variable || waitForInput.booleanRef == variable || 
+                waitForSeconds.floatRef == variable || fadeWhenDone.booleanRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
 

--- a/Assets/Fungus/Scripts/Commands/DebugLog.cs
+++ b/Assets/Fungus/Scripts/Commands/DebugLog.cs
@@ -67,5 +67,18 @@ namespace Fungus
         }
 
         #endregion
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(logMessage.Value, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
     }
 }

--- a/Assets/Fungus/Scripts/Commands/DebugLog.cs
+++ b/Assets/Fungus/Scripts/Commands/DebugLog.cs
@@ -66,6 +66,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return logMessage.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Editor caches

--- a/Assets/Fungus/Scripts/Commands/DeleteSaveKey.cs
+++ b/Assets/Fungus/Scripts/Commands/DeleteSaveKey.cs
@@ -53,5 +53,18 @@ namespace Fungus
         }
 
         #endregion
-    }    
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(key, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
+    }
 }

--- a/Assets/Fungus/Scripts/Commands/ExecuteLua.cs
+++ b/Assets/Fungus/Scripts/Commands/ExecuteLua.cs
@@ -203,6 +203,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return returnVariable == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/FadeSprite.cs
+++ b/Assets/Fungus/Scripts/Commands/FadeSprite.cs
@@ -66,6 +66,12 @@ namespace Fungus
             return new Color32(221, 184, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _duration.floatRef == variable || _targetColor.colorRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/FadeUI.cs
+++ b/Assets/Fungus/Scripts/Commands/FadeUI.cs
@@ -163,6 +163,12 @@ namespace Fungus
             return true;
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return targetColor.colorRef == variable || targetAlpha.floatRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/GetText.cs
+++ b/Assets/Fungus/Scripts/Commands/GetText.cs
@@ -82,6 +82,12 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return stringVariable == variable || 
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/GetToggleState.cs
+++ b/Assets/Fungus/Scripts/Commands/GetToggleState.cs
@@ -54,6 +54,12 @@ namespace Fungus
             return toggle.name;
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return toggleState == variable || 
+                base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/InvokeEvent.cs
+++ b/Assets/Fungus/Scripts/Commands/InvokeEvent.cs
@@ -153,6 +153,13 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return booleanParameter.booleanRef == variable || integerParameter.integerRef == variable ||
+                floatParameter.floatRef == variable || stringParameter.stringRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Jump.cs
+++ b/Assets/Fungus/Scripts/Commands/Jump.cs
@@ -61,6 +61,12 @@ namespace Fungus
             return new Color32(253, 253, 150, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _targetLabel.stringRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/LeanTween/BaseLeanTweenCommand.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/BaseLeanTweenCommand.cs
@@ -110,6 +110,11 @@ namespace Fungus
             return new Color32(233, 163, 180, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _targetObject.gameObjectRef || variable == _duration.floatRef;
+        }
+
         #endregion
 
     }

--- a/Assets/Fungus/Scripts/Commands/LeanTween/MoveLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/MoveLean.cs
@@ -50,6 +50,10 @@ namespace Fungus
             else
                 return LeanTween.move(_targetObject.Value, loc, _duration);
         }
-        
+
+        public override bool HasReference(Variable variable)
+        {
+            return _toTransform.transformRef == variable || _toPosition.vector3Ref == variable || base.HasReference(variable);
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/LeanTween/RotateLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/RotateLean.cs
@@ -70,5 +70,10 @@ namespace Fungus
             else
                 return LeanTween.rotate(_targetObject.Value, rot, _duration);
         }
+
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _toTransform.transformRef || _toRotation.vector3Ref == variable || base.HasReference(variable);
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ScaleLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ScaleLean.cs
@@ -42,5 +42,10 @@ namespace Fungus
 
             return LeanTween.scale(_targetObject.Value, sc, _duration);
         }
+        
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _toTransform.transformRef || _toScale.vector3Ref == variable || base.HasReference(variable);
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/LeanTween/StopTweensLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/StopTweensLean.cs
@@ -43,5 +43,10 @@ namespace Fungus
         {
             return new Color32(233, 163, 180, 255);
         }
+
+        public override bool HasReference(Variable variable)
+        {
+            return _targetObject.gameObjectRef == variable;
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/LoadScene.cs
+++ b/Assets/Fungus/Scripts/Commands/LoadScene.cs
@@ -50,6 +50,12 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _sceneName.stringRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/LoadVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/LoadVariable.cs
@@ -100,5 +100,17 @@ namespace Fungus
         }
 
         #endregion
-    }    
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(key, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
+    }
 }

--- a/Assets/Fungus/Scripts/Commands/LoadVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/LoadVariable.cs
@@ -99,6 +99,12 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable in_variable)
+        {
+            return this.variable == in_variable ||
+                base.HasReference(in_variable);
+        }
+
         #endregion
         #region Editor caches
 #if UNITY_EDITOR

--- a/Assets/Fungus/Scripts/Commands/LookFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/LookFrom.cs
@@ -61,6 +61,12 @@ namespace Fungus
             iTween.LookFrom(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _fromTransform.transformRef == variable || _fromPosition.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/LookTo.cs
+++ b/Assets/Fungus/Scripts/Commands/LookTo.cs
@@ -61,6 +61,12 @@ namespace Fungus
             iTween.LookTo(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _toTransform.transformRef == variable || _toPosition.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/Math/Abs.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Abs.cs
@@ -17,10 +17,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Abs";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/BaseUnaryMathCommand.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/BaseUnaryMathCommand.cs
@@ -21,5 +21,15 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override string GetSummary()
+        {
+            return "in: " + (inValue.floatRef != null ? inValue.floatRef.Key : inValue.Value.ToString()) + 
+                   ", out: " + (outValue.floatRef != null ? outValue.floatRef.Key : outValue.Value.ToString());
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return variable == inValue.floatRef || variable == outValue.floatRef;
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Clamp.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Clamp.cs
@@ -55,7 +55,16 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return Mode.Clamp.ToString() + (mode != Mode.Clamp ? " & " + mode.ToString() : "");
+            if (outValue.floatRef == null)
+                return "Error: no output value selected";
+
+            return outValue.floatRef.Key + " = " + Mode.Clamp.ToString() + (mode != Mode.Clamp ? " & " + mode.ToString() : "");
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return lower.floatRef == variable || upper.floatRef == variable || value.floatRef == variable ||
+                   outValue.floatRef == variable;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/Math/Curve.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Curve.cs
@@ -20,10 +20,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Curve";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Exp.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Exp.cs
@@ -17,10 +17,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Exp";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Inv.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Inv.cs
@@ -19,10 +19,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Inverse 1/f";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/InvLerp.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/InvLerp.cs
@@ -35,7 +35,16 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return "InvLerp [" + a.Value.ToString() + "-" + b.Value.ToString() + "]";
+            if (outValue.floatRef == null)
+                return "Error: no out value selected";
+
+            return outValue.floatRef.Key + " = [" + a.Value.ToString() + "-" + b.Value.ToString() + "]";
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return a.floatRef == variable || b.floatRef == variable || value.floatRef == variable ||
+                   outValue.floatRef == variable;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/Math/Lerp.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Lerp.cs
@@ -54,6 +54,12 @@ namespace Fungus
             return mode.ToString() + " [" + a.Value.ToString() + "-" + b.Value.ToString() + "]";
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return a.floatRef == variable || b.floatRef == variable || percentage.floatRef == variable ||
+                   outValue.floatRef == variable;
+        }
+
         public override Color GetButtonColor()
         {
             return new Color32(235, 191, 217, 255);

--- a/Assets/Fungus/Scripts/Commands/Math/Log.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Log.cs
@@ -40,17 +40,7 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            switch (mode)
-            {
-                case Mode.Base10:
-                    return "Log Base 10";
-                case Mode.Natural:
-                    return "Natural Log";
-                default:
-                    break;
-            }
-
-            return "Log";
+            return mode.ToString() + " " + base.GetSummary();
         }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Map.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Map.cs
@@ -40,6 +40,13 @@ namespace Fungus
                 newRangeLower.Value.ToString() + "-" + newRangeUpper.Value.ToString() + "]";
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return initialRangeLower.floatRef == variable || initialRangeUpper.floatRef == variable || value.floatRef == variable ||
+                   newRangeLower.floatRef == variable || newRangeUpper.floatRef == variable ||
+                   outValue.floatRef == variable;
+        }
+
         public override Color GetButtonColor()
         {
             return new Color32(235, 191, 217, 255);

--- a/Assets/Fungus/Scripts/Commands/Math/MinMax.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/MinMax.cs
@@ -43,19 +43,24 @@ namespace Fungus
                     break;
             }
 
-
             Continue();
         }
 
         public override string GetSummary()
         {
-            return function.ToString();
+            return function.ToString() + " " +
+                "out: " + (outValue.floatRef != null ? outValue.floatRef.Key : outValue.Value.ToString()) +
+                " [" + inLHSValue.Value.ToString() + " - " + inRHSValue.Value.ToString() + "]";
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return inLHSValue.floatRef == variable || inRHSValue.floatRef == variable || outValue.floatRef == variable;
         }
 
         public override Color GetButtonColor()
         {
             return new Color32(235, 191, 217, 255);
         }
-
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Neg.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Neg.cs
@@ -17,10 +17,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Negate";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Pow.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Pow.cs
@@ -27,7 +27,10 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return "Pow";
+            if (outValue.floatRef == null)
+                return "Error: No out value selected";
+
+            return outValue.floatRef.Key + " = " + baseValue.Value.ToString() + "^" + exponentValue.Value.ToString();
         }
 
         public override Color GetButtonColor()
@@ -35,5 +38,10 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return baseValue.floatRef == variable || exponentValue.floatRef == variable ||
+                   outValue.floatRef == variable;
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Round.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Round.cs
@@ -44,7 +44,7 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return function.ToString();
+            return function.ToString() + " " + base.GetSummary();
         }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Sign.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Sign.cs
@@ -17,10 +17,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Sign";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Sqrt.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Sqrt.cs
@@ -17,10 +17,5 @@ namespace Fungus
 
             Continue();
         }
-
-        public override string GetSummary()
-        {
-            return "Sqrt";
-        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/ToInt.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/ToInt.cs
@@ -35,17 +35,17 @@ namespace Fungus
         {
             switch (function)
             {
-                case Mode.RoundToInt:
-                    outValue.Value = Mathf.RoundToInt(inValue.Value);
-                    break;
-                case Mode.FloorToInt:
-                    outValue.Value = Mathf.FloorToInt(inValue.Value);
-                    break;
-                case Mode.CeilToInt:
-                    outValue.Value = Mathf.CeilToInt(inValue.Value);
-                    break;
-                default:
-                    break;
+            case Mode.RoundToInt:
+                outValue.Value = Mathf.RoundToInt(inValue.Value);
+                break;
+            case Mode.FloorToInt:
+                outValue.Value = Mathf.FloorToInt(inValue.Value);
+                break;
+            case Mode.CeilToInt:
+                outValue.Value = Mathf.CeilToInt(inValue.Value);
+                break;
+            default:
+                break;
             }
 
             Continue();
@@ -53,7 +53,9 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return function.ToString();
+            return function.ToString() + 
+                   " in: " + (inValue.floatRef != null ? inValue.floatRef.Key : inValue.Value.ToString()) + 
+                   ", out: " + (outValue.integerRef != null ? outValue.integerRef.Key : outValue.Value.ToString()); ;
         }
 
         public override Color GetButtonColor()
@@ -61,5 +63,9 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == inValue.floatRef || variable == outValue.integerRef;
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Math/Trig.cs
+++ b/Assets/Fungus/Scripts/Commands/Math/Trig.cs
@@ -22,8 +22,7 @@ namespace Fungus
             Sin,
             Tan
         }
-
-
+        
         [Tooltip("Trigonometric function to run.")]
         [SerializeField]
         protected Function function = Function.Sin;
@@ -65,13 +64,7 @@ namespace Fungus
 
         public override string GetSummary()
         {
-            return function.ToString();
+            return function.ToString() + " " + base.GetSummary();
         }
-
-        public override Color GetButtonColor()
-        {
-            return new Color32(235, 191, 217, 255);
-        }
-
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Menu.cs
+++ b/Assets/Fungus/Scripts/Commands/Menu.cs
@@ -121,5 +121,18 @@ namespace Fungus
         }
 
         #endregion
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(text, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Menu.cs
+++ b/Assets/Fungus/Scripts/Commands/Menu.cs
@@ -95,6 +95,12 @@ namespace Fungus
             return new Color32(184, 210, 235, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return interactable.booleanRef == variable || hideThisOption.booleanRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region ILocalizable implementation

--- a/Assets/Fungus/Scripts/Commands/MenuTimer.cs
+++ b/Assets/Fungus/Scripts/Commands/MenuTimer.cs
@@ -62,6 +62,12 @@ namespace Fungus
             return new Color32(184, 210, 235, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _duration.floatRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/MoveAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveAdd.cs
@@ -40,6 +40,12 @@ namespace Fungus
             iTween.MoveAdd(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _offset.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/MoveFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveFrom.cs
@@ -50,6 +50,12 @@ namespace Fungus
             iTween.MoveFrom(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _fromTransform.transformRef == variable || _fromPosition.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/MoveTo.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveTo.cs
@@ -50,6 +50,12 @@ namespace Fungus
             iTween.MoveTo(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _toTransform.transformRef == variable || _toPosition.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/OpenURL.cs
+++ b/Assets/Fungus/Scripts/Commands/OpenURL.cs
@@ -36,6 +36,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return url.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/PlayAnimState.cs
+++ b/Assets/Fungus/Scripts/Commands/PlayAnimState.cs
@@ -53,6 +53,13 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return animator.animatorRef == variable || stateName.stringRef == variable || 
+                layer.integerRef == variable || time.floatRef == variable || 
+                base.HasReference(variable);
+        }
+
         #endregion
     }    
 }

--- a/Assets/Fungus/Scripts/Commands/PlayUsfxrSound.cs
+++ b/Assets/Fungus/Scripts/Commands/PlayUsfxrSound.cs
@@ -83,6 +83,11 @@ using UnityEngine.Serialization;
             return new Color32(128, 200, 200, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _SettingsString.stringRef;
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/Priority/FungusPriorityCount.cs
+++ b/Assets/Fungus/Scripts/Commands/Priority/FungusPriorityCount.cs
@@ -30,5 +30,10 @@ namespace Fungus
             }
             return outVar.Key;
         }
+
+        public override bool HasReference(Variable variable)
+        {
+            return outVar == variable;
+        }
     }
 }

--- a/Assets/Fungus/Scripts/Commands/PunchPosition.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchPosition.cs
@@ -40,6 +40,11 @@ namespace Fungus
             iTween.PunchPosition(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _amount.vector3Ref;
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/PunchRotation.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchRotation.cs
@@ -40,6 +40,11 @@ namespace Fungus
             iTween.PunchRotation(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _amount.vector3Ref;
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/PunchScale.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchScale.cs
@@ -36,6 +36,11 @@ namespace Fungus
             iTween.PunchScale(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _amount.vector3Ref;
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/RandomFloat.cs
+++ b/Assets/Fungus/Scripts/Commands/RandomFloat.cs
@@ -48,7 +48,7 @@ namespace Fungus
 
         public override bool HasReference(Variable variable)
         {
-            return (variable == this.variable);
+            return (variable == this.variable) || minValue.floatRef == variable || maxValue.floatRef == variable;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/RandomInteger.cs
+++ b/Assets/Fungus/Scripts/Commands/RandomInteger.cs
@@ -48,7 +48,7 @@ namespace Fungus
 
         public override bool HasReference(Variable variable)
         {
-            return (variable == this.variable);
+            return (variable == this.variable) || minValue.integerRef == variable || maxValue.integerRef == variable;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/ResetAnimTrigger.cs
+++ b/Assets/Fungus/Scripts/Commands/ResetAnimTrigger.cs
@@ -49,6 +49,12 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _animator.animatorRef == variable || _parameterName.stringRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/RotateAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateAdd.cs
@@ -40,6 +40,12 @@ namespace Fungus
             iTween.RotateAdd(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _offset.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/RotateFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateFrom.cs
@@ -50,6 +50,12 @@ namespace Fungus
             iTween.RotateFrom(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _fromTransform.transformRef == variable || _fromRotation.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/RotateTo.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateTo.cs
@@ -50,6 +50,12 @@ namespace Fungus
             iTween.RotateTo(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _toTransform.transformRef == variable || _toRotation.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SaveVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SaveVariable.cs
@@ -104,5 +104,17 @@ namespace Fungus
         }
 
         #endregion
-    }    
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(key, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
+    }
 }

--- a/Assets/Fungus/Scripts/Commands/SaveVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SaveVariable.cs
@@ -103,6 +103,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable in_variable)
+        {
+            return this.variable == in_variable || base.HasReference(in_variable);
+        }
+
         #endregion
         #region Editor caches
 #if UNITY_EDITOR

--- a/Assets/Fungus/Scripts/Commands/ScaleAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleAdd.cs
@@ -36,6 +36,12 @@ namespace Fungus
             iTween.ScaleAdd(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _offset.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/ScaleFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleFrom.cs
@@ -46,6 +46,12 @@ namespace Fungus
             iTween.ScaleFrom(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _fromTransform.transformRef == variable || _fromScale.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/ScaleTo.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleTo.cs
@@ -46,6 +46,12 @@ namespace Fungus
             iTween.ScaleTo(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _toTransform.transformRef == variable || _toScale.vector3Ref == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SendMessage.cs
+++ b/Assets/Fungus/Scripts/Commands/SendMessage.cs
@@ -84,6 +84,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _message.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetActive.cs
+++ b/Assets/Fungus/Scripts/Commands/SetActive.cs
@@ -49,6 +49,12 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _targetGameObject.gameObjectRef == variable || activeState.booleanRef == variable || 
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetAnimBool.cs
+++ b/Assets/Fungus/Scripts/Commands/SetAnimBool.cs
@@ -52,6 +52,12 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _animator.animatorRef == variable || _parameterName.stringRef == variable || value.booleanRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetAnimFloat.cs
+++ b/Assets/Fungus/Scripts/Commands/SetAnimFloat.cs
@@ -52,6 +52,12 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _animator.animatorRef == variable || _parameterName.stringRef == variable || value.floatRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetAnimInteger.cs
+++ b/Assets/Fungus/Scripts/Commands/SetAnimInteger.cs
@@ -52,6 +52,12 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _animator.animatorRef == variable || _parameterName.stringRef == variable || value.integerRef == variable || 
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetAnimTrigger.cs
+++ b/Assets/Fungus/Scripts/Commands/SetAnimTrigger.cs
@@ -49,6 +49,11 @@ namespace Fungus
             return new Color32(170, 204, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _animator.animatorRef == variable || _parameterName.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetClickable2D.cs
+++ b/Assets/Fungus/Scripts/Commands/SetClickable2D.cs
@@ -44,7 +44,12 @@ namespace Fungus
         
         public override Color GetButtonColor()
         {
-            return new Color32(235, 191, 217, 255); 
+            return new Color32(235, 191, 217, 255);
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return activeState.booleanRef == variable || base.HasReference(variable);
         }
 
         #endregion

--- a/Assets/Fungus/Scripts/Commands/SetCollider.cs
+++ b/Assets/Fungus/Scripts/Commands/SetCollider.cs
@@ -102,6 +102,11 @@ namespace Fungus
             return propertyName == "targetObjects";
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return activeState.booleanRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
         

--- a/Assets/Fungus/Scripts/Commands/SetDraggable2D.cs
+++ b/Assets/Fungus/Scripts/Commands/SetDraggable2D.cs
@@ -47,6 +47,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return activeState.booleanRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetInteractable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetInteractable.cs
@@ -101,6 +101,11 @@ namespace Fungus
             return false;
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return interactableState.booleanRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetLanguage.cs
+++ b/Assets/Fungus/Scripts/Commands/SetLanguage.cs
@@ -48,6 +48,11 @@ namespace Fungus
             return new Color32(184, 210, 235, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _languageCode.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/SetSliderValue.cs
+++ b/Assets/Fungus/Scripts/Commands/SetSliderValue.cs
@@ -47,6 +47,11 @@ namespace Fungus
             return slider.name + " = " + value.GetDescription();
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return value.floatRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetSpriteOrder.cs
+++ b/Assets/Fungus/Scripts/Commands/SetSpriteOrder.cs
@@ -80,6 +80,11 @@ namespace Fungus
             targetSprites.Add(null);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return orderInLayer.integerRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetText.cs
+++ b/Assets/Fungus/Scripts/Commands/SetText.cs
@@ -82,6 +82,20 @@ namespace Fungus
 
         #endregion
 
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(text, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
+
         #region ILocalizable implementation
 
         public virtual string GetStandardText()

--- a/Assets/Fungus/Scripts/Commands/SetText.cs
+++ b/Assets/Fungus/Scripts/Commands/SetText.cs
@@ -80,6 +80,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return text.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
 

--- a/Assets/Fungus/Scripts/Commands/SetToggleState.cs
+++ b/Assets/Fungus/Scripts/Commands/SetToggleState.cs
@@ -47,6 +47,11 @@ namespace Fungus
             return toggle.name + " = " + value.GetDescription();
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return value.booleanRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -319,5 +319,18 @@ namespace Fungus
         }
 
         #endregion
+
+        #region Editor caches
+#if UNITY_EDITOR
+        protected override void RefreshVariableCache()
+        {
+            base.RefreshVariableCache();
+
+            var f = GetFlowchart();
+
+            f.DetermineSubstituteVariables(stringData.Value, referencedVariables);
+        }
+#endif
+        #endregion Editor caches
     }
 }

--- a/Assets/Fungus/Scripts/Commands/SetVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/SetVariable.cs
@@ -92,83 +92,86 @@ namespace Fungus
                 return;
             }
 
-            if (variable.GetType() == typeof(BooleanVariable))
+
+            var t = variable.GetType();
+
+            if (t == typeof(BooleanVariable))
             {
                 BooleanVariable booleanVariable = (variable as BooleanVariable);
                 booleanVariable.Apply(setOperator, booleanData.Value);
             }
-            else if (variable.GetType() == typeof(IntegerVariable))
+            else if (t == typeof(IntegerVariable))
             {
                 IntegerVariable integerVariable = (variable as IntegerVariable);
                 integerVariable.Apply(setOperator, integerData.Value);
             }
-            else if (variable.GetType() == typeof(FloatVariable))
+            else if (t == typeof(FloatVariable))
             {
                 FloatVariable floatVariable = (variable as FloatVariable);
                 floatVariable.Apply(setOperator, floatData.Value);
             }
-            else if (variable.GetType() == typeof(StringVariable))
+            else if (t == typeof(StringVariable))
             {
                 StringVariable stringVariable = (variable as StringVariable);
                 var flowchart = GetFlowchart();
                 stringVariable.Apply(setOperator, flowchart.SubstituteVariables(stringData.Value));
             }
-            else if (variable.GetType() == typeof(AnimatorVariable))
+            else if (t == typeof(AnimatorVariable))
             {
                 AnimatorVariable animatorVariable = (variable as AnimatorVariable);
                 animatorVariable.Apply(setOperator, animatorData.Value);
             }
-            else if (variable.GetType() == typeof(AudioSourceVariable))
+            else if (t == typeof(AudioSourceVariable))
             {
                 AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
                 audioSourceVariable.Apply(setOperator, audioSourceData.Value);
             }
-            else if (variable.GetType() == typeof(ColorVariable))
+            else if (t == typeof(ColorVariable))
             {
                 ColorVariable colorVariable = (variable as ColorVariable);
                 colorVariable.Apply(setOperator, colorData.Value);
             }
-            else if (variable.GetType() == typeof(GameObjectVariable))
+            else if (t == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
                 gameObjectVariable.Apply(setOperator, gameObjectData.Value);
             }
-            else if (variable.GetType() == typeof(MaterialVariable))
+            else if (t == typeof(MaterialVariable))
             {
                 MaterialVariable materialVariable = (variable as MaterialVariable);
                 materialVariable.Apply(setOperator, materialData.Value);
             }
-            else if (variable.GetType() == typeof(ObjectVariable))
+            else if (t == typeof(ObjectVariable))
             {
                 ObjectVariable objectVariable = (variable as ObjectVariable);
                 objectVariable.Apply(setOperator, objectData.Value);
             }
-            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            else if (t == typeof(Rigidbody2DVariable))
             {
                 Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
                 rigidbody2DVariable.Apply(setOperator, rigidbody2DData.Value);
             }
-            else if (variable.GetType() == typeof(SpriteVariable))
+            else if (t == typeof(SpriteVariable))
             {
                 SpriteVariable spriteVariable = (variable as SpriteVariable);
                 spriteVariable.Apply(setOperator, spriteData.Value);
             }
-            else if (variable.GetType() == typeof(TextureVariable))
+            else if (t == typeof(TextureVariable))
             {
                 TextureVariable textureVariable = (variable as TextureVariable);
                 textureVariable.Apply(setOperator, textureData.Value);
             }
-            else if (variable.GetType() == typeof(TransformVariable))
+            else if (t == typeof(TransformVariable))
             {
                 TransformVariable transformVariable = (variable as TransformVariable);
                 transformVariable.Apply(setOperator, transformData.Value);
             }
-            else if (variable.GetType() == typeof(Vector2Variable))
+            else if (t == typeof(Vector2Variable))
             {
                 Vector2Variable vector2Variable = (variable as Vector2Variable);
                 vector2Variable.Apply(setOperator, vector2Data.Value);
             }
-            else if (variable.GetType() == typeof(Vector3Variable))
+            else if (t == typeof(Vector3Variable))
             {
                 Vector3Variable vector3Variable = (variable as Vector3Variable);
                 vector3Variable.Apply(setOperator, vector3Data.Value);
@@ -240,67 +243,69 @@ namespace Fungus
                 break;
             }
 
-            if (variable.GetType() == typeof(BooleanVariable))
+            var t = variable.GetType();
+
+            if (t == typeof(BooleanVariable))
             {
                 description += booleanData.GetDescription();
             }
-            else if (variable.GetType() == typeof(IntegerVariable))
+            else if (t == typeof(IntegerVariable))
             {
                 description += integerData.GetDescription();
             }
-            else if (variable.GetType() == typeof(FloatVariable))
+            else if (t == typeof(FloatVariable))
             {
                 description += floatData.GetDescription();
             }
-            else if (variable.GetType() == typeof(StringVariable))
+            else if (t == typeof(StringVariable))
             {
                 description += stringData.GetDescription();
             }
-            else if (variable.GetType() == typeof(AnimatorVariable))
+            else if (t == typeof(AnimatorVariable))
             {
                 description += animatorData.GetDescription();
             }
-            else if (variable.GetType() == typeof(AudioSourceVariable))
+            else if (t == typeof(AudioSourceVariable))
             {
                 description += audioSourceData.GetDescription();
             }
-            else if (variable.GetType() == typeof(ColorVariable))
+            else if (t == typeof(ColorVariable))
             {
                 description += colorData.GetDescription();
             }
-            else if (variable.GetType() == typeof(GameObjectVariable))
+            else if (t == typeof(GameObjectVariable))
             {
                 description += gameObjectData.GetDescription();
             }
-            else if (variable.GetType() == typeof(MaterialVariable))
+            else if (t == typeof(MaterialVariable))
             {
                 description += materialData.GetDescription();
             }
-            else if (variable.GetType() == typeof(ObjectVariable))
+            else if (t == typeof(ObjectVariable))
             {
                 description += objectData.GetDescription();
             }
-            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            else if (t == typeof(Rigidbody2DVariable))
             {
                 description += rigidbody2DData.GetDescription();
             }
-            else if (variable.GetType() == typeof(SpriteVariable))
+            else if (t == typeof(SpriteVariable))
             {
                 description += spriteData.GetDescription();
             }
-            else if (variable.GetType() == typeof(TextureVariable))
+            else if (t == typeof(TextureVariable))
             {
                 description += textureData.GetDescription();
             }
-            else if (variable.GetType() == typeof(TransformVariable))
+            else if (t == typeof(TransformVariable))
             {
                 description += transformData.GetDescription();
             }
-            else if (variable.GetType() == typeof(Vector2Variable))
+            else if (t == typeof(Vector2Variable))
             {
                 description += vector2Data.GetDescription();
             }
-            else if (variable.GetType() == typeof(Vector3Variable))
+            else if (t == typeof(Vector3Variable))
             {
                 description += vector3Data.GetDescription();
             }
@@ -310,7 +315,77 @@ namespace Fungus
 
         public override bool HasReference(Variable variable)
         {
-            return (variable == this.variable);
+            bool retval = (variable == this.variable) || base.HasReference(variable);
+
+            var t = variable.GetType();
+
+            //this is a nightmare
+            if (t == typeof(BooleanVariable))
+            {
+                retval |= booleanData.booleanRef == variable;
+            }
+            else if (t == typeof(IntegerVariable))
+            {
+                retval |= integerData.integerRef == variable;
+            }
+            else if (t == typeof(FloatVariable))
+            {
+                retval |= floatData.floatRef == variable;
+            }
+            else if (t == typeof(StringVariable))
+            {
+                retval |= stringData.stringRef == variable;
+            }
+            else if (t == typeof(AnimatorVariable))
+            {
+                retval |= animatorData.animatorRef == variable;
+            }
+            else if (t == typeof(AudioSourceVariable))
+            {
+                retval |= audioSourceData.audioSourceRef == variable;
+            }
+            else if (t == typeof(ColorVariable))
+            {
+                retval |= colorData.colorRef == variable;
+            }
+            else if (t == typeof(GameObjectVariable))
+            {
+                retval |= gameObjectData.gameObjectRef == variable;
+            }
+            else if (t == typeof(MaterialVariable))
+            {
+                retval |= materialData.materialRef == variable;
+            }
+            else if (t == typeof(ObjectVariable))
+            {
+                retval |= objectData.objectRef == variable;
+            }
+            else if (t == typeof(Rigidbody2DVariable))
+            {
+                retval |= rigidbody2DData.rigidbody2DRef == variable;
+            }
+            else if (t == typeof(SpriteVariable))
+            {
+                retval |= spriteData.spriteRef == variable;
+            }
+            else if (t == typeof(TextureVariable))
+            {
+                retval |= textureData.textureRef == variable;
+            }
+            else if (t == typeof(TransformVariable))
+            {
+                retval |= transformData.transformRef == variable;
+            }
+            else if (t == typeof(Vector2Variable))
+            {
+                retval |= vector2Data.vector2Ref == variable;
+            }
+            else if (t == typeof(Vector3Variable))
+            {
+                retval |= vector3Data.vector3Ref == variable;
+            }
+
+            return retval;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/ShakePosition.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakePosition.cs
@@ -55,6 +55,11 @@ namespace Fungus
             iTween.ShakePosition(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _amount.vector3Ref == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/ShakeRotation.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakeRotation.cs
@@ -40,6 +40,11 @@ namespace Fungus
             iTween.ShakeRotation(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _amount.vector3Ref == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/ShakeScale.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakeScale.cs
@@ -36,6 +36,11 @@ namespace Fungus
             iTween.ShakeScale(_targetObject.Value, tweenParams);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _amount.vector3Ref == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/ShowSprite.cs
+++ b/Assets/Fungus/Scripts/Commands/ShowSprite.cs
@@ -71,6 +71,11 @@ namespace Fungus
             return new Color32(221, 184, 169, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _visible.booleanRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/StopBlock.cs
+++ b/Assets/Fungus/Scripts/Commands/StopBlock.cs
@@ -55,6 +55,11 @@ namespace Fungus
             return new Color32(253, 253, 150, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return blockName.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/StopTween.cs
+++ b/Assets/Fungus/Scripts/Commands/StopTween.cs
@@ -27,6 +27,11 @@ namespace Fungus
             Continue();
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _tweenName.stringRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/TweenUI.cs
+++ b/Assets/Fungus/Scripts/Commands/TweenUI.cs
@@ -132,6 +132,11 @@ namespace Fungus
             return false;
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return waitUntilFinished.booleanRef == variable || duration.floatRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/VariableCondition.cs
+++ b/Assets/Fungus/Scripts/Commands/VariableCondition.cs
@@ -87,82 +87,84 @@ namespace Fungus
 
             bool condition = false;
 
-            if (variable.GetType() == typeof(BooleanVariable))
+            var t = variable.GetType();
+
+            if (t == typeof(BooleanVariable))
             {
                 BooleanVariable booleanVariable = (variable as BooleanVariable);
                 condition = booleanVariable.Evaluate(compareOperator, booleanData.Value);
             }
-            else if (variable.GetType() == typeof(IntegerVariable))
+            else if (t == typeof(IntegerVariable))
             {
                 IntegerVariable integerVariable = (variable as IntegerVariable);
                 condition = integerVariable.Evaluate(compareOperator, integerData.Value);
             }
-            else if (variable.GetType() == typeof(FloatVariable))
+            else if (t == typeof(FloatVariable))
             {
                 FloatVariable floatVariable = (variable as FloatVariable);
                 condition = floatVariable.Evaluate(compareOperator, floatData.Value);
             }
-            else if (variable.GetType() == typeof(StringVariable))
+            else if (t == typeof(StringVariable))
             {
                 StringVariable stringVariable = (variable as StringVariable);
                 condition = stringVariable.Evaluate(compareOperator, stringData.Value);
             }
-            else if (variable.GetType() == typeof(AnimatorVariable))
+            else if (t == typeof(AnimatorVariable))
             {
                 AnimatorVariable animatorVariable = (variable as AnimatorVariable);
                 condition = animatorVariable.Evaluate(compareOperator, animatorData.Value);
             }
-            else if (variable.GetType() == typeof(AudioSourceVariable))
+            else if (t == typeof(AudioSourceVariable))
             {
                 AudioSourceVariable audioSourceVariable = (variable as AudioSourceVariable);
                 condition = audioSourceVariable.Evaluate(compareOperator, audioSourceData.Value);
             }
-            else if (variable.GetType() == typeof(ColorVariable))
+            else if (t == typeof(ColorVariable))
             {
                 ColorVariable colorVariable = (variable as ColorVariable);
                 condition = colorVariable.Evaluate(compareOperator, colorData.Value);
             }
-            else if (variable.GetType() == typeof(GameObjectVariable))
+            else if (t == typeof(GameObjectVariable))
             {
                 GameObjectVariable gameObjectVariable = (variable as GameObjectVariable);
                 condition = gameObjectVariable.Evaluate(compareOperator, gameObjectData.Value);
             }
-            else if (variable.GetType() == typeof(MaterialVariable))
+            else if (t == typeof(MaterialVariable))
             {
                 MaterialVariable materialVariable = (variable as MaterialVariable);
                 condition = materialVariable.Evaluate(compareOperator, materialData.Value);
             }
-            else if (variable.GetType() == typeof(ObjectVariable))
+            else if (t == typeof(ObjectVariable))
             {
                 ObjectVariable objectVariable = (variable as ObjectVariable);
                 condition = objectVariable.Evaluate(compareOperator, objectData.Value);
             }
-            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            else if (t == typeof(Rigidbody2DVariable))
             {
                 Rigidbody2DVariable rigidbody2DVariable = (variable as Rigidbody2DVariable);
                 condition = rigidbody2DVariable.Evaluate(compareOperator, rigidbody2DData.Value);
             }
-            else if (variable.GetType() == typeof(SpriteVariable))
+            else if (t == typeof(SpriteVariable))
             {
                 SpriteVariable spriteVariable = (variable as SpriteVariable);
                 condition = spriteVariable.Evaluate(compareOperator, spriteData.Value);
             }
-            else if (variable.GetType() == typeof(TextureVariable))
+            else if (t == typeof(TextureVariable))
             {
                 TextureVariable textureVariable = (variable as TextureVariable);
                 condition = textureVariable.Evaluate(compareOperator, textureData.Value);
             }
-            else if (variable.GetType() == typeof(TransformVariable))
+            else if (t == typeof(TransformVariable))
             {
                 TransformVariable transformVariable = (variable as TransformVariable);
                 condition = transformVariable.Evaluate(compareOperator, transformData.Value);
             }
-            else if (variable.GetType() == typeof(Vector2Variable))
+            else if (t == typeof(Vector2Variable))
             {
                 Vector2Variable vector2Variable = (variable as Vector2Variable);
                 condition = vector2Variable.Evaluate(compareOperator, vector2Data.Value);
             }
-            else if (variable.GetType() == typeof(Vector3Variable))
+            else if (t == typeof(Vector3Variable))
             {
                 Vector3Variable vector3Variable = (variable as Vector3Variable);
                 condition = vector3Variable.Evaluate(compareOperator, vector3Data.Value);
@@ -209,70 +211,72 @@ namespace Fungus
                 return "Error: No variable selected";
             }
 
+            var t = variable.GetType();
+
             string summary = variable.Key + " ";
             summary += Condition.GetOperatorDescription(compareOperator) + " ";
 
-            if (variable.GetType() == typeof(BooleanVariable))
+            if (t == typeof(BooleanVariable))
             {
                 summary += booleanData.GetDescription();
             }
-            else if (variable.GetType() == typeof(IntegerVariable))
+            else if (t == typeof(IntegerVariable))
             {
                 summary += integerData.GetDescription();
             }
-            else if (variable.GetType() == typeof(FloatVariable))
+            else if (t == typeof(FloatVariable))
             {
                 summary += floatData.GetDescription();
             }
-            else if (variable.GetType() == typeof(StringVariable))
+            else if (t == typeof(StringVariable))
             {
                 summary += stringData.GetDescription();
             }
-            else if (variable.GetType() == typeof(AnimatorVariable))
+            else if (t == typeof(AnimatorVariable))
             {
                 summary += animatorData.GetDescription();
             }
-            else if (variable.GetType() == typeof(AudioSourceVariable))
+            else if (t == typeof(AudioSourceVariable))
             {
                 summary += audioSourceData.GetDescription();
             }
-            else if (variable.GetType() == typeof(ColorVariable))
+            else if (t == typeof(ColorVariable))
             {
                 summary += colorData.GetDescription();
             }
-            else if (variable.GetType() == typeof(GameObjectVariable))
+            else if (t == typeof(GameObjectVariable))
             {
                 summary += gameObjectData.GetDescription();
             }
-            else if (variable.GetType() == typeof(MaterialVariable))
+            else if (t == typeof(MaterialVariable))
             {
                 summary += materialData.GetDescription();
             }
-            else if (variable.GetType() == typeof(ObjectVariable))
+            else if (t == typeof(ObjectVariable))
             {
                 summary += objectData.GetDescription();
             }
-            else if (variable.GetType() == typeof(Rigidbody2DVariable))
+            else if (t == typeof(Rigidbody2DVariable))
             {
                 summary += rigidbody2DData.GetDescription();
             }
-            else if (variable.GetType() == typeof(SpriteVariable))
+            else if (t == typeof(SpriteVariable))
             {
                 summary += spriteData.GetDescription();
             }
-            else if (variable.GetType() == typeof(TextureVariable))
+            else if (t == typeof(TextureVariable))
             {
                 summary += textureData.GetDescription();
             }
-            else if (variable.GetType() == typeof(TransformVariable))
+            else if (t == typeof(TransformVariable))
             {
                 summary += transformData.GetDescription();
             }
-            else if (variable.GetType() == typeof(Vector2Variable))
+            else if (t == typeof(Vector2Variable))
             {
                 summary += vector2Data.GetDescription();
             }
-            else if (variable.GetType() == typeof(Vector3Variable))
+            else if (t == typeof(Vector3Variable))
             {
                 summary += vector3Data.GetDescription();
             }
@@ -282,7 +286,77 @@ namespace Fungus
 
         public override bool HasReference(Variable variable)
         {
-            return (variable == this.variable);
+            bool retval = (variable == this.variable) || base.HasReference(variable);
+
+            var t = variable.GetType();
+
+            //this is a nightmare
+            if (t == typeof(BooleanVariable))
+            {
+                retval |= booleanData.booleanRef == variable;
+            }
+            else if (t == typeof(IntegerVariable))
+            {
+                retval |= integerData.integerRef == variable;
+            }
+            else if (t == typeof(FloatVariable))
+            {
+                retval |= floatData.floatRef == variable;
+            }
+            else if (t == typeof(StringVariable))
+            {
+                retval |= stringData.stringRef == variable;
+            }
+            else if (t == typeof(AnimatorVariable))
+            {
+                retval |= animatorData.animatorRef == variable;
+            }
+            else if (t == typeof(AudioSourceVariable))
+            {
+                retval |= audioSourceData.audioSourceRef == variable;
+            }
+            else if (t == typeof(ColorVariable))
+            {
+                retval |= colorData.colorRef == variable;
+            }
+            else if (t == typeof(GameObjectVariable))
+            {
+                retval |= gameObjectData.gameObjectRef == variable;
+            }
+            else if (t == typeof(MaterialVariable))
+            {
+                retval |= materialData.materialRef == variable;
+            }
+            else if (t == typeof(ObjectVariable))
+            {
+                retval |= objectData.objectRef == variable;
+            }
+            else if (t == typeof(Rigidbody2DVariable))
+            {
+                retval |= rigidbody2DData.rigidbody2DRef == variable;
+            }
+            else if (t == typeof(SpriteVariable))
+            {
+                retval |= spriteData.spriteRef == variable;
+            }
+            else if (t == typeof(TextureVariable))
+            {
+                retval |= textureData.textureRef == variable;
+            }
+            else if (t == typeof(TransformVariable))
+            {
+                retval |= transformData.transformRef == variable;
+            }
+            else if (t == typeof(Vector2Variable))
+            {
+                retval |= vector2Data.vector2Ref == variable;
+            }
+            else if (t == typeof(Vector3Variable))
+            {
+                retval |= vector3Data.vector3Ref == variable;
+            }
+
+            return retval;
         }
 
         public override Color GetButtonColor()

--- a/Assets/Fungus/Scripts/Commands/Wait.cs
+++ b/Assets/Fungus/Scripts/Commands/Wait.cs
@@ -41,6 +41,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _duration.floatRef == variable || base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Commands/WaitFrames.cs
+++ b/Assets/Fungus/Scripts/Commands/WaitFrames.cs
@@ -49,6 +49,11 @@ namespace Fungus
             return new Color32(235, 191, 217, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return frameCount.integerRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/Write.cs
+++ b/Assets/Fungus/Scripts/Commands/Write.cs
@@ -155,6 +155,11 @@ namespace Fungus
             return "WRITE." + GetFlowchartLocalizationId() + "." + itemId;
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return text.stringRef == variable || setAlpha.floatRef == variable || setColor.colorRef == variable || base.HasReference(variable);
+        }
+
         #endregion
     }
 }

--- a/Assets/Fungus/Scripts/Commands/iTweenCommand.cs
+++ b/Assets/Fungus/Scripts/Commands/iTweenCommand.cs
@@ -108,6 +108,12 @@ namespace Fungus
             return new Color32(233, 163, 180, 255);
         }
 
+        public override bool HasReference(Variable variable)
+        {
+            return _targetObject.gameObjectRef == variable || _tweenName.stringRef == variable ||
+                base.HasReference(variable);
+        }
+
         #endregion
 
         #region Backwards compatibility

--- a/Assets/Fungus/Scripts/Components/Command.cs
+++ b/Assets/Fungus/Scripts/Components/Command.cs
@@ -50,6 +50,30 @@ namespace Fungus
 
         protected string errorMessage = "";
 
+        #region Editor caches
+#if UNITY_EDITOR
+        //
+        protected List<Variable> referencedVariables = new List<Variable>();
+
+        //used by var list adapter to highlight variables 
+        public bool IsVariableReferenced(Variable variable)
+        {
+            return referencedVariables.Contains(variable) || HasReference(variable);
+        }
+
+        /// <summary>
+        /// Called by OnValidate
+        /// 
+        /// Child classes to specialise to add variable references to referencedVariables, either directly or
+        /// via the use of Flowchart.DetermineSubstituteVariables
+        /// </summary>
+        protected virtual void RefreshVariableCache()
+        {
+            referencedVariables.Clear();
+        }
+#endif
+        #endregion Editor caches
+
         #region Public members
 
         /// <summary>
@@ -202,6 +226,16 @@ namespace Fungus
         public virtual bool HasReference(Variable variable)
         {
             return false;
+        }
+
+        /// <summary>
+        /// Called by unity when script is loaded or its data changed by editor
+        /// </summary>
+        public virtual void OnValidate()
+        {
+#if UNITY_EDITOR
+            RefreshVariableCache();
+#endif
         }
 
         /// <summary>

--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -1264,6 +1264,23 @@ namespace Fungus
             }
         }
 
+        public virtual void DetermineSubstituteVariables(string str, List<Variable> vars)
+        {
+            Regex r = new Regex(Flowchart.SubstituteVariableRegexString);
+
+            // Match the regular expression pattern against a text string.
+            var results = r.Matches(str);
+            for (int i = 0; i < results.Count; i++)
+            {
+                var match = results[i];
+                var v = GetVariable(match.Value.Substring(2, match.Value.Length - 3));
+                if (v != null)
+                {
+                    vars.Add(v);
+                }
+            }
+        }
+
         #endregion
 
         #region IStringSubstituter implementation

--- a/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
@@ -178,7 +178,7 @@ namespace Fungus.EditorUtils
             {
                 if (Application.isPlaying && flowchart.SelectedBlock.IsExecuting())
                 {
-                    highlight = flowchart.SelectedBlock.ActiveCommand.HasReference(variable);
+                    highlight = flowchart.SelectedBlock.ActiveCommand.IsVariableReferenced(variable);
                 }
                 else if (!Application.isPlaying && flowchart.SelectedCommands.Count > 0)
                 {
@@ -189,7 +189,7 @@ namespace Fungus.EditorUtils
                             continue;
                         }
 
-                        if (selectedCommand.HasReference(variable))
+                        if (selectedCommand.IsVariableReferenced(variable))
                         {
                             highlight = true;
                             break;


### PR DESCRIPTION
Many commands now have more thorough HasReference implementations.
- Added to some commands, such as iTween commands
- Checking more variables and data in some commands, such as SetVariable
- Added new referenced variable cache list to commands for non trivial checks.
-- This is now used in all commands that used the SubstituteVariable, such as Conversation, on a string variable to show the variables that will be used in the inspector by that substitution.