### PR TITLE
Editor List Caching Fix

### DIFF
--- a/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
@@ -11,11 +11,21 @@ namespace Fungus.EditorUtils
     /// </summary>
     public class CommandSelectorPopupWindowContent : BasePopupWindowContent
     {
-        static List<System.Type> commandTypes;
+        static List<System.Type> _commandTypes;
+        static List<System.Type> CommandTypes
+        {
+            get
+            {
+                if (_commandTypes == null || _commandTypes.Count == 0)
+                    CacheCommandTypes();
+
+                return _commandTypes;
+            }
+        }
 
         static void CacheCommandTypes()
         {
-            commandTypes = EditorExtensions.FindDerivedTypes(typeof(Command)).Where(x => !x.IsAbstract).ToList();
+            _commandTypes = EditorExtensions.FindDerivedTypes(typeof(Command)).Where(x => !x.IsAbstract).ToList();
         }
 
         [UnityEditor.Callbacks.DidReloadScripts]
@@ -34,24 +44,18 @@ namespace Fungus.EditorUtils
 
         protected override void SelectByOrigIndex(int index)
         {
-            var commandType = (index >= 0 && index < commandTypes.Count) ? commandTypes[index] : null;
+            var commandType = (index >= 0 && index < CommandTypes.Count) ? CommandTypes[index] : null;
             AddCommandCallback(commandType);
         }
 
         protected override void PrepareAllItems()
         {
-            if (commandTypes == null || commandTypes.Count == 0)
-            {
-                CacheCommandTypes();
-            }
-
-
             filteredAttributes = GetFilteredSupportedCommands(curBlock.GetFlowchart());
 
             foreach (var item in filteredAttributes)
             {
                 //force lookup to orig index here to account for commmand lists being filtered by users
-                var newFilteredItem = new FilteredListItem(commandTypes.IndexOf(item.Key), (item.Value.Category.Length > 0 ? item.Value.Category + CATEGORY_CHAR : "") + item.Value.CommandName, item.Value.HelpText);
+                var newFilteredItem = new FilteredListItem(CommandTypes.IndexOf(item.Key), (item.Value.Category.Length > 0 ? item.Value.Category + CATEGORY_CHAR : "") + item.Value.CommandName, item.Value.HelpText);
                 allItems.Add(newFilteredItem);
             }
         }
@@ -79,7 +83,7 @@ namespace Fungus.EditorUtils
 
         protected static List<KeyValuePair<System.Type, CommandInfoAttribute>> GetFilteredSupportedCommands(Flowchart flowchart)
         {
-            List<KeyValuePair<System.Type, CommandInfoAttribute>> filteredAttributes = BlockEditor.GetFilteredCommandInfoAttribute(commandTypes);
+            List<KeyValuePair<System.Type, CommandInfoAttribute>> filteredAttributes = BlockEditor.GetFilteredCommandInfoAttribute(CommandTypes);
 
             filteredAttributes.Sort(BlockEditor.CompareCommandAttributes);
 

--- a/Assets/Fungus/Scripts/Editor/PopupContent/EventSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/EventSelectorPopupWindowContent.cs
@@ -11,11 +11,21 @@ namespace Fungus.EditorUtils
     /// </summary>
     public class EventSelectorPopupWindowContent : BasePopupWindowContent
     {
-        static List<System.Type> eventHandlerTypes;
+        static List<System.Type> _eventHandlerTypes;
+        static List<System.Type> EventHandlerTypes
+        {
+            get
+            {
+                if (_eventHandlerTypes == null || _eventHandlerTypes.Count == 0)
+                    CacheEventHandlerTypes();
+
+                return _eventHandlerTypes;
+            }
+        }
 
         static void CacheEventHandlerTypes()
         {
-            eventHandlerTypes = EditorExtensions.FindDerivedTypes(typeof(EventHandler)).Where(x => !x.IsAbstract).ToList();
+            _eventHandlerTypes = EditorExtensions.FindDerivedTypes(typeof(EventHandler)).Where(x => !x.IsAbstract).ToList();
         }
 
         [UnityEditor.Callbacks.DidReloadScripts]
@@ -39,13 +49,8 @@ namespace Fungus.EditorUtils
 
         protected override void PrepareAllItems()
         {
-            if (eventHandlerTypes == null || eventHandlerTypes.Count == 0)
-            {
-                CacheEventHandlerTypes();
-            }
-
             int i = 0;
-            foreach (System.Type type in eventHandlerTypes)
+            foreach (System.Type type in EventHandlerTypes)
             {
                 EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(type);
                 if (info != null)
@@ -65,7 +70,7 @@ namespace Fungus.EditorUtils
         {
             SetEventHandlerOperation operation = new SetEventHandlerOperation();
             operation.block = block;
-            operation.eventHandlerType = (index >= 0 && index < eventHandlerTypes.Count) ? eventHandlerTypes[index] : null;
+            operation.eventHandlerType = (index >= 0 && index < EventHandlerTypes.Count) ? EventHandlerTypes[index] : null;
             OnSelectEventHandler(operation);
         }
 
@@ -93,7 +98,7 @@ namespace Fungus.EditorUtils
             eventHandlerMenu.AddItem(new GUIContent("None"), false, OnSelectEventHandler, noneOperation);
 
             // Add event handlers with no category first
-            foreach (System.Type type in eventHandlerTypes)
+            foreach (System.Type type in EventHandlerTypes)
             {
                 EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(type);
                 if (info != null &&
@@ -108,7 +113,7 @@ namespace Fungus.EditorUtils
             }
 
             // Add event handlers with a category afterwards
-            foreach (System.Type type in eventHandlerTypes)
+            foreach (System.Type type in EventHandlerTypes)
             {
                 EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(type);
                 if (info != null &&

--- a/Assets/Fungus/Scripts/Editor/PopupContent/VariableSelectPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/VariableSelectPopupWindowContent.cs
@@ -12,12 +12,22 @@ namespace Fungus.EditorUtils
     public class VariableSelectPopupWindowContent : BasePopupWindowContent
     {
         static readonly int POPUP_WIDTH = 200, POPUP_HEIGHT = 200;
-        static List<System.Type> types;
+        static List<System.Type> _variableTypes;
+        static List<System.Type> VariableTypes
+        {
+            get
+            {
+                if (_variableTypes == null || _variableTypes.Count == 0)
+                    CacheVariableTypes();
+
+                return _variableTypes;
+            }
+        }
 
         static void CacheVariableTypes()
         {
             var derivedType = typeof(Variable);
-            types = EditorExtensions.FindDerivedTypes(derivedType)
+            _variableTypes = EditorExtensions.FindDerivedTypes(derivedType)
                 .Where(x => !x.IsAbstract && derivedType.IsAssignableFrom(x))
                 .ToList();
         }
@@ -30,13 +40,8 @@ namespace Fungus.EditorUtils
 
         protected override void PrepareAllItems()
         {
-            if(types == null || types.Count == 0)
-            {
-                CacheVariableTypes();
-            }
-
             int i = 0;
-            foreach (var item in types)
+            foreach (var item in VariableTypes)
             {
                 VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(item);
                 if (variableInfo != null)
@@ -50,7 +55,7 @@ namespace Fungus.EditorUtils
 
         protected override void SelectByOrigIndex(int index)
         {
-            AddVariable(types[index]);
+            AddVariable(VariableTypes[index]);
         }
 
         static public void DoAddVariable(Rect position, string currentHandlerName, Flowchart flowchart)
@@ -71,7 +76,7 @@ namespace Fungus.EditorUtils
             GenericMenu menu = new GenericMenu();
 
             // Add variable types without a category
-            foreach (var type in types)
+            foreach (var type in VariableTypes)
             {
                 VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(type);
                 if (variableInfo == null ||
@@ -86,7 +91,7 @@ namespace Fungus.EditorUtils
             }
 
             // Add types with a category
-            foreach (var type in types)
+            foreach (var type in VariableTypes)
             {
                 VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(type);
                 if (variableInfo == null ||


### PR DESCRIPTION
Convert Variable Type list, EventHandler Type list and Command Type list to property
-force init cache of access, this solves the 'Cannot add variable' style errors that have been reported