### PR TITLE
Mushroom icon for the inspector moved in 2019...

### DIFF
--- a/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
+++ b/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
@@ -66,7 +66,11 @@ namespace Fungus
 
             // place the icon to the left of the element
             Rect r = new Rect(selectionRect);
+#if UNITY_2019_1_OR_NEWER
+            r.x -= r.height;
+#else
             r.x = 0;
+#endif
             r.width = r.height;
 
             //GameObject go = EditorUtility.InstanceIDToObject(instanceID) as GameObject;


### PR DESCRIPTION
as to not overlap the new visibility toggle Unity has added.