### PR TITLE
EditorUtils.FindDerivedTypes now finds within ALL assembles

### DIFF
--- a/Assets/Fungus/Scripts/Editor/EditorExtensions.cs
+++ b/Assets/Fungus/Scripts/Editor/EditorExtensions.cs
@@ -4,6 +4,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEditor;
 
 namespace Fungus.EditorUtils
 {
@@ -52,7 +53,7 @@ namespace Fungus.EditorUtils
         }
 
         /// <summary>
-        /// A convenient method for calling the above.
+        /// A convenient method for calling the above, but for ALL assemblies.
         /// Example usage:
         ///     List<System.Type> subTypes = EditorUtility.FindDerivedTypes(typeof(BaseTimelineEvent)).ToList();
         /// </summary>
@@ -61,7 +62,21 @@ namespace Fungus.EditorUtils
         /// <returns></returns>
         public static System.Type[] FindDerivedTypes(System.Type baseType, bool classOnly = true)
         {
-            return FindDerivedTypesFromAssembly(System.Reflection.Assembly.GetAssembly(baseType), baseType, classOnly);
+#if UNITY_2019_2_OR_NEWER
+            var results = TypeCache.GetTypesDerivedFrom(baseType).ToArray();
+            if (classOnly)
+                return results.Where(x => x.IsClass).ToArray();
+            else
+                return results.ToArray();
+#else
+            System.Type[] typeArray = new System.Type[0];
+            var retval = typeArray.Concat(typeArray);
+            foreach (var assem in System.AppDomain.CurrentDomain.GetAssemblies())
+            {
+                retval = retval.Concat(FindDerivedTypesFromAssembly(assem, baseType, classOnly));
+            }
+            return retval.ToArray();
+#endif
         }
     }
 }


### PR DESCRIPTION
-Uses TypeCache if available

Required to support use of asmdef, also would fix #734 