### PR TITLE
Added warnings when MenuDialog

### DIFF
--- a/Assets/Fungus/Scripts/Components/MenuDialog.cs
+++ b/Assets/Fungus/Scripts/Components/MenuDialog.cs
@@ -294,8 +294,10 @@ namespace Fungus
         private bool AddOption(string text, bool interactable, bool hideOption, UnityEngine.Events.UnityAction action)
         {
             if (nextOptionIndex >= CachedButtons.Length)
+            {
+                Debug.LogWarning("Unable to add menu item, not enough buttons: " + text);
                 return false;
-
+            }
             //if first option notify that a menu has started
             if(nextOptionIndex == 0)
                 MenuSignals.DoMenuStart(this);
@@ -343,6 +345,10 @@ namespace Fungus
                 gameObject.SetActive(true);
                 StopAllCoroutines();
                 StartCoroutine(WaitForTimeout(duration, targetBlock));
+            }
+            else
+            {
+                Debug.LogWarning("Unable to show timer, no slider set");
             }
         }
 


### PR DESCRIPTION
-Menu item requested when there are non left
-Timer requested when none is available

Related to forum issues raised here, [link](http://fungusgames.com/forum#!/general:why-doesnt-my-menu-option)