### PR TITLE
Fix for BlockInspector Crash

### DIFF
--- a/Assets/Fungus/Scripts/Editor/BlockInspector.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockInspector.cs
@@ -97,7 +97,7 @@ namespace Fungus.EditorUtils
                 !block.Equals(activeBlockEditor.target))
             {
                 DestroyImmediate(activeBlockEditor);
-                activeBlockEditor = Editor.CreateEditor(block) as BlockEditor;
+                activeBlockEditor = Editor.CreateEditor(block, typeof(BlockEditor)) as BlockEditor;
             }
 
             UpdateWindowHeight();


### PR DESCRIPTION
On some newer versions of Unity, the BlockInspector will crash whenever the user selects a block in the flowchart window.
The inspector window will not populate, and the console will throw null reference errors every editor frame as long as the block is selected.
This is due to `activeBlockEditor` never getting instantiated properly. I suspect that this is due to recent API changes that made `Editor.CreateEditor(block)` create a generic Editor object, instead of a BlockEditor. Since the object is not actually the extended type, the reference becomes null after being cast using `as`.

The fix is to change this line to `Editor.CreateEditor(block, typeof(BlockEditor))`

This overload parameter ensures that the object is instantiated using the correct type. This fix should work for all versions, as it appears to have been an API option since at least Unity 5.2.

Tested on Unity 2018.0.1f1 and 2019.2.1f1