### PR TITLE
Add option to Grid Snap block in flowchart window

### DIFF
--- a/Assets/Fungus/Scripts/Components/Block.cs
+++ b/Assets/Fungus/Scripts/Components/Block.cs
@@ -375,6 +375,12 @@ namespace Fungus
         public virtual List<Block> GetConnectedBlocks()
         {
             var connectedBlocks = new List<Block>();
+            GetConnectedBlocks(ref connectedBlocks);
+            return connectedBlocks;
+        }
+
+        public virtual void GetConnectedBlocks(ref List<Block> connectedBlocks)
+        {
             for (int i = 0; i < commandList.Count; i++)
             {
                 var command = commandList[i];
@@ -383,7 +389,6 @@ namespace Fungus
                     command.GetConnectedBlocks(ref connectedBlocks);
                 }
             }
-            return connectedBlocks;
         }
 
         /// <summary>

--- a/Assets/Fungus/Scripts/Editor/EditorZoomArea.cs
+++ b/Assets/Fungus/Scripts/Editor/EditorZoomArea.cs
@@ -52,6 +52,22 @@ namespace Fungus.EditorUtils
             result.y += pivotPoint.y;
             return result;
         }
+
+        public static Rect SnapPosition(this Rect rect, float snapInterval)
+        {
+            var tmp = rect;
+            var x = tmp.position.x;
+            var y = tmp.position.y;
+            tmp.position = new Vector2(Mathf.RoundToInt(x / snapInterval) * snapInterval, Mathf.RoundToInt(y / snapInterval) * snapInterval);
+            return tmp;
+        }
+
+        public static Rect SnapWidth(this Rect rect, float snapInterval)
+        {
+            var tmp = rect;
+            tmp.width = Mathf.RoundToInt(tmp.width / snapInterval) * snapInterval;
+            return tmp;
+        }
     }
 
     public class EditorZoomArea

--- a/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
@@ -21,9 +21,11 @@ namespace Fungus
             private static bool prefsLoaded = false;
             private const string HIDE_MUSH_KEY = "hideMushroomInHierarchy";
             private const string USE_LEGACY_MENUS = "useLegacyMenus";
+            private const string USE_GRID_SNAP = "useGridSnap";
 
             public static bool hideMushroomInHierarchy;
             public static bool useLegacyMenus;
+            public static bool useGridSnap;
 
             static FungusEditorPreferences()
             {
@@ -63,6 +65,7 @@ namespace Fungus
                 // Preferences GUI
                 hideMushroomInHierarchy = EditorGUILayout.Toggle("Hide Mushroom Flowchart Icon", hideMushroomInHierarchy);
                 useLegacyMenus = EditorGUILayout.Toggle(new GUIContent("Legacy Menus", "Force Legacy menus for Event, Add Variable and Add Command menus"), useLegacyMenus);
+                useGridSnap = EditorGUILayout.Toggle(new GUIContent("Grid Snap", "Align and Snap block positions and widths in the flowchart window to the grid"), useGridSnap);
 
                 EditorGUILayout.Space();
                 //ideally if any are null, but typically it is all or nothing that have broken links due to version changes or moving files external to Unity
@@ -113,6 +116,7 @@ namespace Fungus
                 {
                     EditorPrefs.SetBool(HIDE_MUSH_KEY, hideMushroomInHierarchy);
                     EditorPrefs.SetBool(USE_LEGACY_MENUS, useLegacyMenus);
+                    EditorPrefs.SetBool(USE_GRID_SNAP, useGridSnap);
                 }
             }
 
@@ -120,6 +124,7 @@ namespace Fungus
             {
                 hideMushroomInHierarchy = EditorPrefs.GetBool(HIDE_MUSH_KEY, false);
                 useLegacyMenus = EditorPrefs.GetBool(USE_LEGACY_MENUS, false);
+                useGridSnap = EditorPrefs.GetBool(USE_GRID_SNAP, false);
                 prefsLoaded = true;
             }
         }


### PR DESCRIPTION
Controlled via toggle in Fungus Editor Prefs.
Snaps and aligns blocks to underlying grid in the flowchart window.
More caches for styles and lists to reduce allocations during block drawing