### PR TITLE
Heirarchy Icon placement bug in newer Unity versions

### DIFF
--- a/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
+++ b/Assets/Fungus/Scripts/Editor/HierarchyIcons.cs
@@ -70,7 +70,7 @@ namespace Fungus
             // place the icon to the left of the element
             Rect r = new Rect(selectionRect);
 #if UNITY_2019_1_OR_NEWER
-            r.x -= r.height;
+            r.x = 0;
 #else
             r.x = 0;
 #endif


### PR DESCRIPTION
The removed line was not functioning as intended, it was covering the disclosure triangle of a parent GO with the mushroom icon if that parent GO also had a flowchart component.

I'm sure there was a reason for this logic change, so I've left the if cases intact, but this was necessary in my own project so I thought I'd share it.

Tested locally and works fine. This is my first ever community git contribution, so apologies if I've committed a faux pa!