### PR TITLE
Change to Show Null for FungusVariables

### DIFF
--- a/Assets/Fungus/Scripts/Components/Variable.cs
+++ b/Assets/Fungus/Scripts/Components/Variable.cs
@@ -234,7 +234,7 @@ namespace Fungus
             if (Value != null)
                 return Value.ToString();
             else
-                return string.Empty;
+                return "Null";
         }
         
         protected virtual void Start()
@@ -246,7 +246,7 @@ namespace Fungus
         //Apply to get from base system.object to T
         public override void Apply(SetOperator op, object value)
         {
-            if(value is T)
+            if(value is T || value == null)
             {
                 Apply(op, (T)value);
             }
@@ -277,7 +277,7 @@ namespace Fungus
         //Apply to get from base system.object to T
         public override bool Evaluate(CompareOperator op, object value)
         {
-            if (value is T)
+            if (value is T || value == null)
             {
                 return Evaluate(op, (T)value);
             }
@@ -301,10 +301,10 @@ namespace Fungus
             switch (compareOperator)
             {
             case CompareOperator.Equals:
-                condition = Value.Equals(value);
+                condition = Equals(Value, value);// Value.Equals(value);
                 break;
             case CompareOperator.NotEquals:
-                condition = !Value.Equals(value);
+                condition = !Equals(Value, value);
                 break;
             default:
                 Debug.LogError("The " + compareOperator.ToString() + " comparison operator is not valid.");

--- a/Assets/Fungus/Scripts/Utils/AllVariableTypes.cs
+++ b/Assets/Fungus/Scripts/Utils/AllVariableTypes.cs
@@ -285,7 +285,7 @@ namespace Fungus
             {
                 return ta.DescFunc(this);
             }
-            return string.Empty;
+            return "Null";
         }
 
         public bool Compare(CompareOperator compareOperator, ref bool compareResult)

--- a/Assets/Fungus/Scripts/VariableTypes/AnimatorVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/AnimatorVariable.cs
@@ -49,7 +49,7 @@ namespace Fungus
         {
             if (animatorRef == null)
             {
-                return animatorVal != null ? animatorVal.ToString() : string.Empty;
+                return animatorVal != null ? animatorVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/AudioSourceVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/AudioSourceVariable.cs
@@ -49,7 +49,7 @@ namespace Fungus
         {
             if (audioSourceRef == null)
             {
-                return audioSourceVal != null ? audioSourceVal.ToString() : string.Empty;
+                return audioSourceVal != null ? audioSourceVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/CollectionVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/CollectionVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (collectionRef == null)
             {
-                return collectionVal != null ? collectionVal.ToString() : string.Empty;
+                return collectionVal != null ? collectionVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/Collider2DVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Collider2DVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (collider2DRef == null)
             {
-                return collider2DVal != null ? collider2DVal.ToString() : string.Empty;
+                return collider2DVal != null ? collider2DVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/ColliderVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/ColliderVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (colliderRef == null)
             {
-                return colliderVal != null ? colliderVal.ToString() : string.Empty;
+                return colliderVal != null ? colliderVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/GameObjectVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/GameObjectVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (gameObjectRef == null)
             {
-                return gameObjectVal != null ? gameObjectVal.ToString() : string.Empty;
+                return gameObjectVal != null ? gameObjectVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/MaterialVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/MaterialVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (materialRef == null)
             {
-                return materialVal != null ? materialVal.ToString() : string.Empty;
+                return materialVal != null ? materialVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/ObjectVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/ObjectVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (objectRef == null)
             {
-                return objectVal != null ? objectVal.ToString() : string.Empty;
+                return objectVal != null ? objectVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/Rigidbody2DVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/Rigidbody2DVariable.cs
@@ -49,7 +49,7 @@ namespace Fungus
         {
             if (rigidbody2DRef == null)
             {
-                return rigidbody2DVal != null ? rigidbody2DVal.ToString() : string.Empty;
+                return rigidbody2DVal != null ? rigidbody2DVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/RigidbodyVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/RigidbodyVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (rigidbodyRef == null)
             {
-                return rigidbodyVal != null ? rigidbodyVal.ToString() : string.Empty;
+                return rigidbodyVal != null ? rigidbodyVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/SpriteVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/SpriteVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (spriteRef == null)
             {
-                return spriteVal != null ? spriteVal.ToString() : string.Empty;
+                return spriteVal != null ? spriteVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/TextureVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/TextureVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (textureRef == null)
             {
-                return textureVal != null ? textureVal.ToString() : string.Empty;
+                return textureVal != null ? textureVal.ToString() : "Null";
             }
             else
             {

--- a/Assets/Fungus/Scripts/VariableTypes/TransformVariable.cs
+++ b/Assets/Fungus/Scripts/VariableTypes/TransformVariable.cs
@@ -50,7 +50,7 @@ namespace Fungus
         {
             if (transformRef == null)
             {
-                return transformVal != null ? transformVal.ToString() : string.Empty;
+                return transformVal != null ? transformVal.ToString() : "Null";
             }
             else
             {


### PR DESCRIPTION
FungusVariables that are object references now return string of Null rather than string of empty when descriptions are requested. As the result of these calls is often shown to the user in the inspector with in blocks or commands empty made the results less easy to understand.
eg "PlayerGO == " is less readable than "PlayerGO == Null"