### PR TITLE
Fixed massive slowdown in editor when there is MANY objects in the scene

### DIFF
--- a/Assets/Fungus/Scripts/Editor/ViewEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/ViewEditor.cs
@@ -18,17 +18,14 @@ namespace Fungus.EditorUtils
 
         // Draw Views when they're not selected
 #if UNITY_5_0
-        [DrawGizmo(GizmoType.NotSelected | GizmoType.SelectedOrChild)]
+        [DrawGizmo(GizmoType.NotSelected | GizmoType.SelectedOrChild, typeof(View))]
 #else
-        [DrawGizmo(GizmoType.NotInSelectionHierarchy | GizmoType.InSelectionHierarchy)]
+        [DrawGizmo(GizmoType.NotInSelectionHierarchy | GizmoType.InSelectionHierarchy, typeof(View))]
 #endif
         static void RenderCustomGizmo(Transform objectTransform, GizmoType gizmoType)
         {
             View view = objectTransform.gameObject.GetComponent<View>();
-            if (view != null)
-            {
-                DrawView(view, false);
-            }
+	    DrawView(view, false);
         }
 
         protected virtual Vector2 LookupAspectRatio(int index)


### PR DESCRIPTION
### Description
I just got into a project that had the editor run VERY slow. I noticed there was thousands of calls to DrawGizmo even if there wasn't much gizmos in the scene. I narrowed this down to Fungus.EditorUtils.ViewEditor.RenderCustomGizmo which was really surprising because Fungus was not used in the scene I was working on.

Has it turns out, the DrawGizmo attribute was being called for ALL objects in the scene and there is more than ten thousand objects in this scene so it was crippling the performance of the editor. This was easy to fix: just filter out all the objects that don't have the View component by using the second constructor of the DrawGizmo attribute.

### What is the current behavior?
Editor performance being crippled if there is MANY (10000+) objects in a scene even if Fungus is not being used in that scene.

### What is the new behavior?
Normal performance. (0 calls to Fungus.EditorUtils.ViewEditor.RenderCustomGizmo if there is no Fungus View gizmo to render)