### PR TITLE
Fixed issue with variables being modified when the key isn't valid

### DIFF
--- a/Assets/Fungus/Scripts/Commands/LoadVariable.cs
+++ b/Assets/Fungus/Scripts/Commands/LoadVariable.cs
@@ -28,17 +28,18 @@ namespace Fungus
 
         public override void OnEnter()
         {
-            if (key == "" ||
-                variable == null)
+            var flowchart = GetFlowchart();
+
+            // Prepend the current save profile (if any) and make sure all inputs are valid
+            string prefsKey = SetSaveProfile.SaveProfile + "_" + flowchart.SubstituteVariables(key);
+            bool validKey = key != "" && PlayerPrefs.HasKey(prefsKey);
+            bool validVariable = variable != null;
+
+            if (!validKey || !validVariable)
             {
                 Continue();
                 return;
             }
-
-            var flowchart = GetFlowchart();
-
-            // Prepend the current save profile (if any)
-            string prefsKey = SetSaveProfile.SaveProfile + "_" + flowchart.SubstituteVariables(key);
 
             System.Type variableType = variable.GetType();
 


### PR DESCRIPTION
### Description
Bug fix.

### What is the current behavior?
When you try loading an int variable with an invalid key, it gets set to 0 instead of being left alone
Relevant issue: #867 

### What is the new behavior?
LoadVariable checks if the key is valid before making any changes, regardless of variable type.

### Important Notes
- My change modifies the runtime execution/behaviour of the Load Variable command
