### PR TITLE
Add Simple Tint preferences

### DIFF
--- a/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
@@ -162,6 +162,8 @@ namespace Fungus.EditorUtils
                     break;
                 }
             }
+            var prevCol = GUI.color;
+            GUI.color = FungusEditorPreferences.commandListTint;
 
             string commandName = commandInfoAttr.CommandName;
             
@@ -382,6 +384,7 @@ namespace Fungus.EditorUtils
             GUI.Label(summaryRect, summary, summaryStyle);
             
             GUI.backgroundColor = Color.white;
+            GUI.color = prevCol;
         }
     }
 }

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -1419,6 +1419,8 @@ namespace Fungus.EditorUtils
 
             EditorZoomArea.Begin(flowchart.Zoom, scriptViewRect);
 
+            var prevCol = GUI.color;
+
             if (e.type == EventType.Repaint)
             {
                 DrawGrid();
@@ -1464,9 +1466,9 @@ namespace Fungus.EditorUtils
                         (b.ExecutingIconTimer - curRealTime) / FungusConstants.ExecutingIconFadeTime,
                         emptyStyle);
                 }
-                GUI.color = Color.white;
             }
 
+            GUI.color = prevCol;
             EditorZoomArea.End();
         }
 
@@ -2085,7 +2087,7 @@ namespace Fungus.EditorUtils
                 }
             }
 
-            graphics.tint = block.UseCustomTint ? block.Tint : defaultTint;
+            graphics.tint = (block.UseCustomTint ? block.Tint : defaultTint) * FungusEditorPreferences.flowchatBlockTint;
 
             return graphics;
         }

--- a/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
@@ -22,10 +22,14 @@ namespace Fungus
             private const string HIDE_MUSH_KEY = "hideMushroomInHierarchy";
             private const string USE_LEGACY_MENUS = "useLegacyMenus";
             private const string USE_GRID_SNAP = "useGridSnap";
+            private const string COMMAND_LIST_ITEM_TINT = "commandListTint";
+            private const string FLOWCHART_WINDIOW_BLOCK_TINT = "flowchartWindowBlockTint";
 
             public static bool hideMushroomInHierarchy;
             public static bool useLegacyMenus;
             public static bool useGridSnap;
+            public static Color commandListTint = Color.white;
+            public static Color flowchatBlockTint = Color.white;
 
             static FungusEditorPreferences()
             {
@@ -66,6 +70,8 @@ namespace Fungus
                 hideMushroomInHierarchy = EditorGUILayout.Toggle("Hide Mushroom Flowchart Icon", hideMushroomInHierarchy);
                 useLegacyMenus = EditorGUILayout.Toggle(new GUIContent("Legacy Menus", "Force Legacy menus for Event, Add Variable and Add Command menus"), useLegacyMenus);
                 useGridSnap = EditorGUILayout.Toggle(new GUIContent("Grid Snap", "Align and Snap block positions and widths in the flowchart window to the grid"), useGridSnap);
+                flowchatBlockTint = EditorGUILayout.ColorField(new GUIContent("Flowchart Window Block Tint", "Custom tint used on the Block icons in the Flowchart Window. Default is white."), flowchatBlockTint);
+                commandListTint = EditorGUILayout.ColorField(new GUIContent("Command List Tint", "Custom tint used on the Command List in the Block Inspector. Default is white."), commandListTint);
 
                 EditorGUILayout.Space();
                 //ideally if any are null, but typically it is all or nothing that have broken links due to version changes or moving files external to Unity
@@ -117,6 +123,10 @@ namespace Fungus
                     EditorPrefs.SetBool(HIDE_MUSH_KEY, hideMushroomInHierarchy);
                     EditorPrefs.SetBool(USE_LEGACY_MENUS, useLegacyMenus);
                     EditorPrefs.SetBool(USE_GRID_SNAP, useGridSnap);
+                    var colAsString = "#" + ColorUtility.ToHtmlStringRGBA(commandListTint);
+                    EditorPrefs.SetString(COMMAND_LIST_ITEM_TINT, colAsString); 
+                    colAsString = "#" + ColorUtility.ToHtmlStringRGBA(flowchatBlockTint);
+                    EditorPrefs.SetString(FLOWCHART_WINDIOW_BLOCK_TINT, colAsString);
                 }
             }
 
@@ -125,6 +135,15 @@ namespace Fungus
                 hideMushroomInHierarchy = EditorPrefs.GetBool(HIDE_MUSH_KEY, false);
                 useLegacyMenus = EditorPrefs.GetBool(USE_LEGACY_MENUS, false);
                 useGridSnap = EditorPrefs.GetBool(USE_GRID_SNAP, false);
+
+                if(ColorUtility.TryParseHtmlString(EditorPrefs.GetString(COMMAND_LIST_ITEM_TINT), out var col))
+                {
+                    commandListTint = col;
+                }
+                if (ColorUtility.TryParseHtmlString(EditorPrefs.GetString(FLOWCHART_WINDIOW_BLOCK_TINT), out col))
+                {
+                    flowchatBlockTint = col;
+                }
                 prefsLoaded = true;
             }
         }


### PR DESCRIPTION
CommandListAdapter items and Blocks in flowchartwindow have configurable tints in fungus editor preferences.

![image](https://user-images.githubusercontent.com/4897812/93660870-96302f00-fa96-11ea-93b9-b5a2983655b3.png)

### Description
Adding simple tinting for elements of Fungus UI as per close #868 

### What is the new behavior?
In the Fungus Editor Preferences the user can now configure a tint colour for the CommandList in the Block Inspector and a tint for the Block icons in the Flowchart Window.

### Other information
These type of tints are easy to integrate and should remain easy to maintain. I'll wait for feedback before mering this PR in case there are more elements that are requested.