### PR TITLE
Update BlockEditor.cs to support up/down key navigation

### DIFF
--- a/Assets/Fungus/Scripts/Editor/BlockEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockEditor.cs
@@ -315,14 +315,16 @@ namespace Fungus.EditorUtils
 
 
             // Previous Command
-            if ((Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.PageUp))
+            if ((Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.PageUp) ||
+                (Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.UpArrow))
             {
                 SelectPrevious();
                 GUI.FocusControl("dummycontrol");
                 Event.current.Use();
             }
             // Next Command
-            if ((Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.PageDown))
+            if ((Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.PageDown) ||
+                (Event.current.type == EventType.KeyDown) && (Event.current.keyCode == KeyCode.DownArrow))
             {
                 SelectNext();
                 GUI.FocusControl("dummycontrol");


### PR DESCRIPTION
### Description
Added ability to cycle Editor block commands with up/down arrow (already possible with pagedown/pageup)
Related to #879 

### What is the current behavior?
Navigating block commands in the editor is only possible with PageUp and PageDown keys.

### What is the new behavior?
Navigating block commands in the editor is only possible with PageUp and PageDown keys AND Up and Down arrow keys.

### Important Notes
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.