### PR TITLE
Command to control over Active/Non-Active character on stage (WIP)

### DIFF
--- a/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
+++ b/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
@@ -274,7 +274,6 @@ namespace Fungus
                         if (LeanTween.isTweening(c.State.portraitImage.gameObject))
                         {
                             LeanTween.cancel(c.State.portraitImage.gameObject, true);
-                            Continue();
                         }
                     }
                 }
@@ -293,7 +292,6 @@ namespace Fungus
                         {
                             LeanTween.cancel(c.State.portraitImage.gameObject, true);
                             PortraitController.SetRectTransform(c.State.portraitImage.rectTransform, c.State.position);                            
-                            Continue();
                         }
                     }
                 }

--- a/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
+++ b/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
@@ -2,19 +2,24 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using UnityEngine;
+using UnityEngine.UI;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 
 namespace Fungus
 {
 
+
     public enum CharStageDisplayType
     {
-        /// <summary> Disables tween </summary>
+        /// <summary> No operation </summary>
         None,
-        /// <summary> Applies Punch like animation to character. </summary>
+        /// <summary> Applies Wobble animation to character. </summary>
         Wobble,
 
-        /// <summary> Applies Happy animation to character. </summary>
+        /// <summary> Applies Shock animation to character. </summary>
         Shock,
 
         /// <summary> Applies Happy animation to character. </summary>
@@ -22,12 +27,18 @@ namespace Fungus
 
         /// <summary> Applies Panic animation expression to character. </summary>
         Panic,
-        /// <summary> Applies Panic animation expression to character. </summary>
-        Mad        
+
+        /// <summary> Applies Mad animation expression to character. </summary>
+        Mad,
+   
+        /// <summary> Applies Mad animation expression to character. </summary>
+        ZoomIn
+        
+        
     }
 
     /// <summary>
-    /// Controls speaking/non-speaking characters with predefined tween animations.
+    /// Controls the stage on which character portraits are displayed.
     /// </summary>
     [CommandInfo("Animation", 
                  "Character Expression",
@@ -39,214 +50,237 @@ namespace Fungus
         [SerializeField] protected Character character;
         [SerializeField] protected bool AllChar = false;
         [HideInInspector] protected Stage stage;
+        [HideInInspector] public Image characterImage;
         [HideInInspector] protected bool waitUntilFinished = false;
-        [SerializeField] protected bool overideStagePro = true;
+        [SerializeField] protected bool IgnoreStageProperty = true;
+
         protected static Character speakingCharacter;
-        protected virtual void MadSpeakingPortraits(Stage stage) 
-            {
+
+
+
+        protected virtual void MadSpeakingPortraits(Character character)
+        {
                 var prevSpeakingCharacter = speakingCharacter;
                 speakingCharacter = character;
                 
-                var charactersOnStage = stage.CharactersOnStage;
-                for (int j = 0; j < charactersOnStage.Count; j++)               
-                   { 
-                        var c = charactersOnStage[j];
-                        if (c != null && c.Equals(speakingCharacter))
-                            {   
-                                LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.1f);
-                                LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1);                                    
-                            }
-
-                        if(AllChar)                                    
-                            {
-
-                                if (c != null && !c.Equals(speakingCharacter))
-                                {                        
-                            
-                                    for (int i = 0; i < charactersOnStage.Count; i++)
-                                    {
-                                        LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.1f);
-                                        LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1);      
-
-                                    }
-                                }
-                                    
-                            }                                       
-                        if (!waitUntilFinished)
-                            {
-                                Continue();                                
-                            }
-                        if (overideStagePro)
-                            {
-                                stage.SetDimmed(c, false);
-                            }                                     
-                    }                
-                    
-            }
-        protected virtual void WobbleSpeakingPortraits(Stage stage) 
-            {
-                var prevSpeakingCharacter = speakingCharacter;
-                speakingCharacter = character;
-                
-                var charactersOnStage = stage.CharactersOnStage;
-                for (int j = 0; j < charactersOnStage.Count; j++)               
-                { 
-                    var c = charactersOnStage[j];
-                    if (c != null && c.Equals(speakingCharacter))
-                        {   
-
-                            LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 1f).setEase(LeanTweenType.punch).setLoopPingPong(-1);
-                                          
-                        }
-                    if(AllChar)                                    
+                var activeStages = Stage.ActiveStages;
+                for (int i = 0; i < activeStages.Count; i++)
+                {       
+                    var stage = activeStages[i];
+                    if (character != null)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
                         {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && c.Equals(speakingCharacter))
+                                {
+                                    LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.3f);
+                                    LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1); 
+                                } 
+                            }
+                        }
+                    }                
+                }
+            
+            if(AllChar)                                    
+                { 
+                    var charactersOnStage = stage.CharactersOnStage;
+                    for (int i = 0; i < charactersOnStage.Count; i++)
+                        {
+                            var c = charactersOnStage[i];
+                            LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.3f);
+                            LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1);                  
+                        }                            
+                }
 
-                            if (c != null && !c.Equals(speakingCharacter))
-                            {                        
-                           
-                                for (int i = 0; i < charactersOnStage.Count; i++)
+            if (IgnoreStageProperty)
+                {
+                    stage.SetDimmed(character, false);
+                }
+        }
+        protected virtual void WobbleSpeakingPortraits(Character character)
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var activeStages = Stage.ActiveStages;
+                for (int i = 0; i < activeStages.Count; i++)
+                {       
+                    var stage = activeStages[i];
+                    if (character != null)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
+                        {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && c.Equals(speakingCharacter))
                                 {
                                     LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 1f).setEase(LeanTweenType.punch).setLoopPingPong(-1);
-
-                                }
+                                } 
                             }
-                                
-                        }                                    
-                    if (!waitUntilFinished)
-                        {
-                            Continue();                                
                         }
-                    if (overideStagePro)
-                        {
-                            stage.SetDimmed(c, false);
-                        }                                           
+                    }                
                 }
-            }
+            
+            if(AllChar)                                    
+                { 
+                    var charactersOnStage = stage.CharactersOnStage;
+                    for (int i = 0; i < charactersOnStage.Count; i++)
+                        {
+                            var c = charactersOnStage[i];
+                            LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 1f).setEase(LeanTweenType.punch).setLoopPingPong(-1);
+                        }                            
+                }
+
+            if (IgnoreStageProperty)
+                {
+                    stage.SetDimmed(character, false);
+                }                                         
+                     
+                
+        }
 
         // Happy expression
-        protected virtual void HappySpeakingPortraits(Stage stage) 
+        protected virtual void HappySpeakingPortraits(Character character) 
         {
                 var prevSpeakingCharacter = speakingCharacter;
                 speakingCharacter = character;
                 
-                var charactersOnStage = stage.CharactersOnStage;
-                for (int j = 0; j < charactersOnStage.Count; j++)               
-                   { 
-                        var c = charactersOnStage[j];
-                        if (c != null && c.Equals(speakingCharacter))
-                            {   
-                                LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
-                                LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                             
-                            }
-
-                        if(AllChar)                                    
-                            {
-
-                                if (c != null && !c.Equals(speakingCharacter))
-                                {                        
-                            
-                                    for (int i = 0; i < charactersOnStage.Count; i++)
-                                    {
-                                        LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
-                                        LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1); 
-                                    
-                                    }
-                                }
-                                    
-                            }                                        
-                        if (!waitUntilFinished)
-                            {
-                                Continue();                                
-                            }
-                        if (overideStagePro)
-                            {
-                                stage.SetDimmed(c, false);
-                            }                                         
-                    }        
-        }
-
-        protected virtual void ShockSpeakingPortraits(Stage stage) 
-        {
-                var prevSpeakingCharacter = speakingCharacter;
-                speakingCharacter = character;
-                
-                var charactersOnStage = stage.CharactersOnStage;
-                for (int j = 0; j < charactersOnStage.Count; j++)               
-                   { 
-                        var c = charactersOnStage[j];
-                        if (c != null && c.Equals(speakingCharacter))
-                            {   
-                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
-                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
-                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1);                      
-                            }
-
-                        if(AllChar)                                    
-                            {
-
-                                if (c != null && !c.Equals(speakingCharacter))
-                                {                        
-                            
-                                    for (int i = 0; i < charactersOnStage.Count; i++)
-                                    {
-                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
-                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
-                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1); 
-
-                                    }
-                                }
-                                    
-                            }                                    
-                        if (!waitUntilFinished)
-                            {
-                                Continue();                                
-                            }
-                        if (overideStagePro)
-                            {
-                                stage.SetDimmed(c, false);
-                            }           
-                    }    
-        }
-
-        protected virtual void PanicSpeakingPortraits(Stage stage) 
-        {
-                var prevSpeakingCharacter = speakingCharacter;
-                speakingCharacter = character;
-                
-                var charactersOnStage = stage.CharactersOnStage;
-                for (int j = 0; j < charactersOnStage.Count; j++)               
-                   { 
-                    var c = charactersOnStage[j];
-                    if (c != null && c.Equals(speakingCharacter))
-                        {   
-                            LeanTween.moveX(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
-                            LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                             
-                        }
-
-                    if(AllChar)                                    
+                var activeStages = Stage.ActiveStages;
+                for (int i = 0; i < activeStages.Count; i++)
+                {       
+                    var stage = activeStages[i];
+                    if (character != null)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
                         {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && c.Equals(speakingCharacter))
+                                {
+                                    LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.2f);
+                                    LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1); 
+                                } 
+                            }
+                        }
+                    }                
+                }
+            
+            if(AllChar)                                    
+                { 
+                    var charactersOnStage = stage.CharactersOnStage;
+                    for (int i = 0; i < charactersOnStage.Count; i++)
+                        {
+                            var c = charactersOnStage[i];
+                            LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.2f);
+                            LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                    
+                        }                            
+                }
 
-                            if (c != null && !c.Equals(speakingCharacter))
-                            {                        
-                           
-                                for (int i = 0; i < charactersOnStage.Count; i++)
+            if (IgnoreStageProperty)
+                {
+                    stage.SetDimmed(character, false);
+                }                
+        }
+        protected virtual void ShockSpeakingPortraits(Character character)
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var activeStages = Stage.ActiveStages;
+                for (int i = 0; i < activeStages.Count; i++)
+                {       
+                    var stage = activeStages[i];
+                    if (character != null)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
+                        {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && c.Equals(speakingCharacter))
+                                {
+                                    LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
+                                    LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
+                                    LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1); 
+                                } 
+                            }
+                        }
+                    }                
+                }
+            
+            if(AllChar)                                    
+                { 
+                    var charactersOnStage = stage.CharactersOnStage;
+                    for (int i = 0; i < charactersOnStage.Count; i++)
+                        {
+                            var c = charactersOnStage[i];
+                            LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
+                            LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
+                            LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1);                    
+                        }                            
+                }
+
+            if (IgnoreStageProperty)
+                {
+                    stage.SetDimmed(character, false);
+                }   
+        }
+
+        protected virtual void PanicSpeakingPortraits(Character character) 
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var activeStages = Stage.ActiveStages;
+                for (int i = 0; i < activeStages.Count; i++)
+                {       
+                    var stage = activeStages[i];
+                    if (character != null)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
+                        {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && c.Equals(speakingCharacter))
                                 {
                                     LeanTween.moveX(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
-                                    LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);  
-
+                                    LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1); 
                                 }
+
+ 
                             }
-                                
-                        }                                     
-                    if (!waitUntilFinished)
-                        {
-                            Continue();                                
                         }
-                    if (overideStagePro)
+                    }                
+                }
+            
+            if(AllChar)                                    
+                { 
+                    var charactersOnStage = stage.CharactersOnStage;
+                    for (int i = 0; i < charactersOnStage.Count; i++)
                         {
-                            stage.SetDimmed(c, false);
-                        }         
-                    }    
+                            var c = charactersOnStage[i];
+                            LeanTween.moveX(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
+                            LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                  
+                        }                            
+                }
+
+            if (IgnoreStageProperty)
+                {
+                    stage.SetDimmed(character, false);
+                }                                         
+                     
+                
         }
         protected virtual void OnComplete() 
         {
@@ -262,7 +296,6 @@ namespace Fungus
         #region Public members        
         public override void OnEnter()
         {
-
             if(AllChar)
             {
                 var activeCharacters = Character.ActiveCharacters;
@@ -278,7 +311,6 @@ namespace Fungus
                     }
                 }
             }
-
             // If NONE selected, means stop all tweens
             if (IsDisplayNone(display))
             {
@@ -314,19 +346,19 @@ namespace Fungus
             switch(display)
             {            
             case (CharStageDisplayType.Wobble):
-                WobbleSpeakingPortraits(stage);
+                WobbleSpeakingPortraits(character);
                 break;
             case (CharStageDisplayType.Shock):
-                ShockSpeakingPortraits(stage);
+                ShockSpeakingPortraits(character);
                 break;
             case (CharStageDisplayType.Happy):
-                HappySpeakingPortraits(stage);
+                HappySpeakingPortraits(character);
                 break;
             case (CharStageDisplayType.Panic):
-                PanicSpeakingPortraits(stage);
+                PanicSpeakingPortraits(character);
                 break;
             case (CharStageDisplayType.Mad):
-                MadSpeakingPortraits(stage);
+                MadSpeakingPortraits(character);
                 break;
             }
 

--- a/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
+++ b/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
@@ -1,0 +1,371 @@
+// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+
+namespace Fungus
+{
+
+    public enum CharStageDisplayType
+    {
+        /// <summary> No operation </summary>
+        None,
+        /// <summary> Dim all non-speaking portraits on the stage. </summary>
+        Wobble,
+
+        /// <summary> Applies Happy animation to character. </summary>
+        Shock,
+
+        /// <summary> Applies Happy animation to character. </summary>
+        Happy,
+
+        /// <summary> Applies Panic animation expression to character. </summary>
+        Panic,
+        /// <summary> Applies Panic animation expression to character. </summary>
+        Mad        
+    }
+
+    /// <summary>
+    /// Controls the stage on which character portraits are displayed.
+    /// </summary>
+    [CommandInfo("Animation", 
+                 "Character Expression",
+                 "Applies animation to both speaking/non-speaking character on stage. The active state valid until next character sprite change OR it should stop manually, both use cases are safe.")]
+             
+    public class CharacterActiveState : ControlWithDisplay<CharStageDisplayType> 
+    {
+        [Tooltip("Applies animation to active/non-active charracters")]
+        [SerializeField] protected Character character;
+        [SerializeField] protected bool AllChar = false;
+        [HideInInspector] protected Stage stage;
+        [HideInInspector] protected bool waitUntilFinished = false;
+        [SerializeField] protected bool overideStagePro = true;
+        protected static Character speakingCharacter;
+        protected virtual void MadSpeakingPortraits(Stage stage) 
+            {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var charactersOnStage = stage.CharactersOnStage;
+                for (int j = 0; j < charactersOnStage.Count; j++)               
+                   { 
+                        var c = charactersOnStage[j];
+                        if (c != null && c.Equals(speakingCharacter))
+                            {   
+                                LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.1f);
+                                LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1);                                    
+                            }
+
+                        if(AllChar)                                    
+                            {
+
+                                if (c != null && !c.Equals(speakingCharacter))
+                                {                        
+                            
+                                    for (int i = 0; i < charactersOnStage.Count; i++)
+                                    {
+                                        LeanTween.alpha(c.State.portraitImage.rectTransform, 0f, 0.1f).setDelay(0.1f);
+                                        LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 0.2f).setEase(LeanTweenType.punch).setLoopPingPong(-1);      
+
+                                    }
+                                }
+                                    
+                            }                                       
+                        if (!waitUntilFinished)
+                            {
+                                Continue();                                
+                            }
+                        if (overideStagePro)
+                            {
+                                stage.SetDimmed(c, false);
+                            }                                     
+                    }                
+                    
+            }
+        protected virtual void WobbleSpeakingPortraits(Stage stage) 
+            {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var charactersOnStage = stage.CharactersOnStage;
+                for (int j = 0; j < charactersOnStage.Count; j++)               
+                { 
+                    var c = charactersOnStage[j];
+                    if (c != null && c.Equals(speakingCharacter))
+                        {   
+
+                            LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 1f).setEase(LeanTweenType.punch).setLoopPingPong(-1);
+                                          
+                        }
+                    if(AllChar)                                    
+                        {
+
+                            if (c != null && !c.Equals(speakingCharacter))
+                            {                        
+                           
+                                for (int i = 0; i < charactersOnStage.Count; i++)
+                                {
+                                    LeanTween.scale(c.State.portraitImage.rectTransform, Vector3.zero, 1f).setEase(LeanTweenType.punch).setLoopPingPong(-1);
+
+                                }
+                            }
+                                
+                        }                                    
+                    if (!waitUntilFinished)
+                        {
+                            Continue();                                
+                        }
+                    if (overideStagePro)
+                        {
+                            stage.SetDimmed(c, false);
+                        }                                           
+                }
+            }
+
+        // Happy expression
+        protected virtual void HappySpeakingPortraits(Stage stage) 
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var charactersOnStage = stage.CharactersOnStage;
+                for (int j = 0; j < charactersOnStage.Count; j++)               
+                   { 
+                        var c = charactersOnStage[j];
+                        if (c != null && c.Equals(speakingCharacter))
+                            {   
+                                LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
+                                LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                             
+                            }
+
+                        if(AllChar)                                    
+                            {
+
+                                if (c != null && !c.Equals(speakingCharacter))
+                                {                        
+                            
+                                    for (int i = 0; i < charactersOnStage.Count; i++)
+                                    {
+                                        LeanTween.moveY(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
+                                        LeanTween.moveY(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1); 
+                                    
+                                    }
+                                }
+                                    
+                            }                                        
+                        if (!waitUntilFinished)
+                            {
+                                Continue();                                
+                            }
+                        if (overideStagePro)
+                            {
+                                stage.SetDimmed(c, false);
+                            }                                         
+                    }        
+        }
+
+        protected virtual void ShockSpeakingPortraits(Stage stage) 
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var charactersOnStage = stage.CharactersOnStage;
+                for (int j = 0; j < charactersOnStage.Count; j++)               
+                   { 
+                        var c = charactersOnStage[j];
+                        if (c != null && c.Equals(speakingCharacter))
+                            {   
+                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
+                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
+                                LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1);                      
+                            }
+
+                        if(AllChar)                                    
+                            {
+
+                                if (c != null && !c.Equals(speakingCharacter))
+                                {                        
+                            
+                                    for (int i = 0; i < charactersOnStage.Count; i++)
+                                    {
+                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, -12f, 0.2f);
+                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 0f, 0.2f);
+                                        LeanTween.rotateAround(c.State.portraitImage.rectTransform, Vector3.forward, 12f, 0.2f).setLoopPingPong(-1); 
+
+                                    }
+                                }
+                                    
+                            }                                    
+                        if (!waitUntilFinished)
+                            {
+                                Continue();                                
+                            }
+                        if (overideStagePro)
+                            {
+                                stage.SetDimmed(c, false);
+                            }           
+                    }    
+        }
+
+        protected virtual void PanicSpeakingPortraits(Stage stage) 
+        {
+                var prevSpeakingCharacter = speakingCharacter;
+                speakingCharacter = character;
+                
+                var charactersOnStage = stage.CharactersOnStage;
+                for (int j = 0; j < charactersOnStage.Count; j++)               
+                   { 
+                    var c = charactersOnStage[j];
+                    if (c != null && c.Equals(speakingCharacter))
+                        {   
+                            LeanTween.moveX(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
+                            LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);                             
+                        }
+
+                    if(AllChar)                                    
+                        {
+
+                            if (c != null && !c.Equals(speakingCharacter))
+                            {                        
+                           
+                                for (int i = 0; i < charactersOnStage.Count; i++)
+                                {
+                                    LeanTween.moveX(c.State.portraitImage.rectTransform, 100f, 0.2f).setEase(LeanTweenType.easeInQuad).setDelay(0.1f);
+                                    LeanTween.moveX(c.State.portraitImage.rectTransform, -100f, 0.2f).setEase(LeanTweenType.easeInQuad).setLoopPingPong(-1);  
+
+                                }
+                            }
+                                
+                        }                                     
+                    if (!waitUntilFinished)
+                        {
+                            Continue();                                
+                        }
+                    if (overideStagePro)
+                        {
+                            stage.SetDimmed(c, false);
+                        }         
+                    }    
+        }
+        protected virtual void OnComplete() 
+        {
+            if (waitUntilFinished)
+            {
+                Continue();
+            }
+        }    
+
+        public virtual Character _Character { get { return character; } }
+        public Character SpeakingCharacter { get { return speakingCharacter; } }
+
+        #region Public members        
+        public override void OnEnter()
+        {
+
+            if(AllChar)
+            {
+                var activeCharacters = Character.ActiveCharacters;
+                for (int i = 0; i < activeCharacters.Count; i++)
+                {
+                    var c = activeCharacters[i];
+                    if (c.State.portraitImage != null)
+                    {
+                        if (LeanTween.isTweening(c.State.portraitImage.gameObject))
+                        {
+                            LeanTween.cancel(c.State.portraitImage.gameObject, true);
+                            Continue();
+                        }
+                    }
+                }
+            }
+
+            // If NONE selected, means stop all tweens
+            if (IsDisplayNone(display))
+            {
+                var activeCharacters = Character.ActiveCharacters;
+                for (int i = 0; i < activeCharacters.Count; i++)
+                {
+                    var c = activeCharacters[i];
+                    if (c.State.portraitImage != null)
+                    {
+                        if (LeanTween.isTweening(c.State.portraitImage.gameObject))
+                        {
+                            LeanTween.cancel(c.State.portraitImage.gameObject, true);
+                            PortraitController.SetRectTransform(c.State.portraitImage.rectTransform, c.State.position);                            
+                            Continue();
+                        }
+                    }
+                }
+            }
+
+            // Selected "use default Portrait Stage"
+            if (stage == null)           
+            {
+                // If no default specified, try to get any portrait stage in the scene
+                stage = FindObjectOfType<Stage>();
+
+                // If portrait stage does not exist, do nothing
+                if (stage == null)
+                {
+                    Continue();
+                    return;
+                }
+            }           
+            // Use default settings
+            switch(display)
+            {            
+            case (CharStageDisplayType.Wobble):
+                WobbleSpeakingPortraits(stage);
+                break;
+            case (CharStageDisplayType.Shock):
+                ShockSpeakingPortraits(stage);
+                break;
+            case (CharStageDisplayType.Happy):
+                HappySpeakingPortraits(stage);
+                break;
+            case (CharStageDisplayType.Panic):
+                PanicSpeakingPortraits(stage);
+                break;
+            case (CharStageDisplayType.Mad):
+                MadSpeakingPortraits(stage);
+                break;
+            }
+
+            if (!waitUntilFinished)
+            {
+                Continue();
+            }
+        }
+        public override string GetSummary()
+        {
+            string displaySummary = "";
+            if (character != null)
+            {
+                displaySummary = StringFormatter.SplitCamelCase(character.ToString());
+            }
+            else
+            {
+                return "";
+            }
+            string stageSummary = "";
+            if (stage != null)
+            {
+                stageSummary = " \"" + stage.name + "\"";
+            }
+            return displaySummary + stageSummary;
+        }        
+        public override Color GetButtonColor()
+        {
+            return new Color32(230, 200, 250, 255);
+        }
+        public override void OnCommandAdded(Block parentBlock)
+        {
+            //Default to display type: show
+            display = CharStageDisplayType.Happy;
+        }
+        
+    }
+    #endregion
+    
+}

--- a/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
+++ b/Assets/Fungus/Scripts/Commands/CharacterActiveState.cs
@@ -9,9 +9,9 @@ namespace Fungus
 
     public enum CharStageDisplayType
     {
-        /// <summary> No operation </summary>
+        /// <summary> Disables tween </summary>
         None,
-        /// <summary> Dim all non-speaking portraits on the stage. </summary>
+        /// <summary> Applies Punch like animation to character. </summary>
         Wobble,
 
         /// <summary> Applies Happy animation to character. </summary>
@@ -27,7 +27,7 @@ namespace Fungus
     }
 
     /// <summary>
-    /// Controls the stage on which character portraits are displayed.
+    /// Controls speaking/non-speaking characters with predefined tween animations.
     /// </summary>
     [CommandInfo("Animation", 
                  "Character Expression",


### PR DESCRIPTION
### Description
Custom command for flexibility/freedom to control speaking/non-speaking character.

### What is the current behavior?
Currently the way to control character individually is very limited especially the non-active ones. There are ways to address this partially but it requires multiple blocks and Stages, and this PR/custom command is not.

### What is the new behavior?
Add animation to active/non-active and all character on stage based on predefined tween presets.
- Add predefined tween animation to speaking character.
- Add predefined tween animation to non-speaking character.
- Add predefined tween animation to all character on stage.

### Important Notes
- My change require modifications or additions to documentation
- My change adds new custom command

**Workflow of this custom command:**

Command name: Animation/Character Expression

1. It will loop until next character's portrait change so the extra block to stop the tween may not be required
2. To stop the tween just drop the command again and select "None" for single character and uncheck "All char" if in the previous block the All char is checked
3. (Optional) It also compatible with "LeanTween/Stop Tweens" to stop the tweening objects

Please do keep in mind, the idea of this custom command originally to make my game making process simpler so it may not suitable for you. Working with 600+k of words with thousand of commands in one scene is not really convenient and corrections can be HELL! This pr partially address that issue (at least for me).

### Other information
Related to https://github.com/snozbot/fungus/issues/877

Edit: The tween would sometimes stop if user clicks rapidly and I've no idea how to fix this

I may forgot a couple of things that was added, let me know if there are some errors.
