### PR TITLE
Add Support for Obsolete attribute

### DIFF
--- a/Assets/Fungus/Scripts/Commands/MoveAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveAdd.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Move Add", 
                  "Moves a game object by a specified offset over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class MoveAdd : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/MoveFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveFrom.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Move From", 
                  "Moves a game object from a specified position back to its starting position over time. The position can be defined by a transform in another object (using To Transform) or by setting an absolute position (using To Position, if To Transform is set to None).")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class MoveFrom : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/MoveTo.cs
+++ b/Assets/Fungus/Scripts/Commands/MoveTo.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Move To", 
                  "Moves a game object to a specified position over time. The position can be defined by a transform in another object (using To Transform) or by setting an absolute position (using To Position, if To Transform is set to None).")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class MoveTo : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/PunchPosition.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchPosition.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Punch Position", 
                  "Applies a jolt of force to a GameObject's position and wobbles it back to its initial position.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class PunchPosition : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/PunchRotation.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchRotation.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Punch Rotation", 
                  "Applies a jolt of force to a GameObject's rotation and wobbles it back to its initial rotation.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class PunchRotation : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/PunchScale.cs
+++ b/Assets/Fungus/Scripts/Commands/PunchScale.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Punch Scale", 
                  "Applies a jolt of force to a GameObject's scale and wobbles it back to its initial scale.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class PunchScale : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/RotateAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateAdd.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Rotate Add", 
                  "Rotates a game object by the specified angles over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class RotateAdd : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/RotateFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateFrom.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Rotate From", 
                  "Rotates a game object from the specified angles back to its starting orientation over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class RotateFrom : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/RotateTo.cs
+++ b/Assets/Fungus/Scripts/Commands/RotateTo.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Rotate To", 
                  "Rotates a game object to the specified angles over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class RotateTo : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/ScaleAdd.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleAdd.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Scale Add", 
                  "Changes a game object's scale by a specified offset over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ScaleAdd : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/ScaleFrom.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleFrom.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Scale From", 
                  "Changes a game object's scale to the specified value and back to its original scale over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ScaleFrom : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/ScaleTo.cs
+++ b/Assets/Fungus/Scripts/Commands/ScaleTo.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Scale To", 
                  "Changes a game object's scale to a specified value over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ScaleTo : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Editor/BasePopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/BasePopupWindowContent.cs
@@ -88,6 +88,8 @@ namespace Fungus.EditorUtils
             Rect searchRect = new Rect(0, 0, rect.width, EditorStyles.toolbar.fixedHeight);
             Rect scrollRect = Rect.MinMaxRect(0, searchRect.yMax, rect.xMax, rect.yMax);
 
+            GUI.skin.label.richText = true;
+
             HandleKeyboard();
             DrawSearch(searchRect);
             DrawSelectionArea(scrollRect);

--- a/Assets/Fungus/Scripts/Editor/CommandEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandEditor.cs
@@ -61,10 +61,18 @@ namespace Fungus.EditorUtils
                 return;
             }
 
-            CommandInfoAttribute commandInfoAttr = CommandEditor.GetCommandInfo(t.GetType());
+            var commandType = t.GetType();
+
+            CommandInfoAttribute commandInfoAttr = CommandEditor.GetCommandInfo(commandType);
             if (commandInfoAttr == null)
             {
                 return;
+            }
+            
+            var obsAttr = commandType.GetCustomAttribute<System.ObsoleteAttribute>();
+            if(obsAttr != null)
+            {
+                EditorGUILayout.HelpBox(obsAttr.Message, MessageType.Warning, true);
             }
 
             GUILayout.BeginVertical(GUI.skin.box);

--- a/Assets/Fungus/Scripts/Editor/CommandEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandEditor.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using System.Collections.Generic;
 using UnityEditorInternal;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {

--- a/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using UnityEditorInternal;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {
@@ -115,11 +116,15 @@ namespace Fungus.EditorUtils
                 return;
             }
 
-            CommandInfoAttribute commandInfoAttr = CommandEditor.GetCommandInfo(command.GetType());
+            var commandType = command.GetType();
+
+            CommandInfoAttribute commandInfoAttr = CommandEditor.GetCommandInfo(commandType);
             if (commandInfoAttr == null)
             {
                 return;
             }
+
+            var obsAttr = commandType.GetCustomAttribute<System.ObsoleteAttribute>();
 
             var flowchart = (Flowchart)command.GetFlowchart();
             if (flowchart == null)
@@ -139,10 +144,16 @@ namespace Fungus.EditorUtils
             {
                 summary = summary.Replace("\n", "").Replace("\r", "");
             }
+
             if (summary.StartsWith("Error:"))
             {
                 summary = "<color=red> " + summary + "</color>";
             }
+            else if(obsAttr != null)
+            {
+                summary = FungusConstants.UIPrefixForDeprecated_RichText + summary;
+            }
+            
 
             if (isComment || isLabel)
             {

--- a/Assets/Fungus/Scripts/Editor/EventHandlerEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/EventHandlerEditor.cs
@@ -1,6 +1,7 @@
 // This code is part of the Fungus library (https://github.com/snozbot/fungus)
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -66,6 +67,12 @@ namespace Fungus.EditorUtils
             // Doing so could cause block.commandList to contain null entries.
             // To avoid this we manually display all properties, except for m_Script.
             serializedObject.Update();
+
+            var obsAttr = (target as EventHandler).GetType().GetCustomAttribute<System.ObsoleteAttribute>();
+            if (obsAttr != null)
+            {
+                EditorGUILayout.HelpBox(obsAttr.Message, MessageType.Warning, true);
+            }
 
             DrawProperties();
             DrawHelpBox();

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -2183,10 +2183,19 @@ namespace Fungus.EditorUtils
                 if (block._EventHandler != null)
                 {
                     string handlerLabel = "";
-                    EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(block._EventHandler.GetType());
+                    var eventType = block._EventHandler.GetType();
+                    EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(eventType);
                     if (info != null)
                     {
-                        handlerLabel = "<" + info.EventHandlerName + "> ";
+                        var obsAttr = eventType.GetCustomAttribute<System.ObsoleteAttribute>();
+                        if (obsAttr != null)
+                        {
+                            handlerLabel = "<" + FungusConstants.UIPrefixForDeprecated_RichText + info.EventHandlerName + "> ";
+                        }
+                        else
+                        {
+                            handlerLabel = "<" + info.EventHandlerName + "> ";
+                        }
                     }
 
                     Rect rect = new Rect(block._NodeRect);

--- a/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {
@@ -58,8 +59,12 @@ namespace Fungus.EditorUtils
             foreach (var item in filteredAttributes)
             {
                 //force lookup to orig index here to account for commmand lists being filtered by users
-                var newFilteredItem = new FilteredListItem(CommandTypes.IndexOf(item.Key), (item.Value.Category.Length > 0 ? item.Value.Category + CATEGORY_CHAR : "") + item.Value.CommandName, item.Value.HelpText);
-                allItems.Add(newFilteredItem);
+                var obsAttr = item.Key.GetCustomAttribute<System.ObsoleteAttribute>();
+
+                var fliStr = (item.Value.Category.Length > 0 ? item.Value.Category + CATEGORY_CHAR : "") 
+                    + (obsAttr != null ? FungusConstants.UIPrefixForDeprecated_RichText : "")
+                    + item.Value.CommandName;
+                allItems.Add(new FilteredListItem(CommandTypes.IndexOf(item.Key), fliStr, item.Value.HelpText));
             }
         }
 

--- a/Assets/Fungus/Scripts/Editor/PopupContent/EventSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/EventSelectorPopupWindowContent.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {
@@ -53,16 +54,17 @@ namespace Fungus.EditorUtils
         protected override void PrepareAllItems()
         {
             int i = 0;
-            foreach (System.Type type in EventHandlerTypes)
+            foreach (var item in EventHandlerTypes)
             {
-                EventHandlerInfoAttribute info = EventHandlerEditor.GetEventHandlerInfo(type);
+                var info = EventHandlerEditor.GetEventHandlerInfo(item);
                 if (info != null)
                 {
-                    allItems.Add(new FilteredListItem(i, (info.Category.Length > 0 ? info.Category + CATEGORY_CHAR : "") + info.EventHandlerName, info.HelpText));
-                }
-                else
-                {
-                    allItems.Add(new FilteredListItem(i, type.Name, info.HelpText));
+                    var obsAttr = item.GetCustomAttribute<System.ObsoleteAttribute>();
+
+                    var fliStr = (info.Category.Length > 0 ? info.Category + CATEGORY_CHAR : "")
+                        + (obsAttr != null ? FungusConstants.UIPrefixForDeprecated_RichText : "")
+                        + info.EventHandlerName;
+                    allItems.Add(new FilteredListItem(i, fliStr, info.HelpText));
                 }
 
                 i++;

--- a/Assets/Fungus/Scripts/Editor/PopupContent/VariableSelectPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/VariableSelectPopupWindowContent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using System.Linq;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {
@@ -49,7 +50,12 @@ namespace Fungus.EditorUtils
                 VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(item);
                 if (variableInfo != null)
                 {
-                    allItems.Add(new FilteredListItem(i, (variableInfo.Category.Length > 0 ? variableInfo.Category + CATEGORY_CHAR : "") + variableInfo.VariableType));
+                    var obsAttr = item.GetCustomAttribute<System.ObsoleteAttribute>();
+
+                    var fliStr = (variableInfo.Category.Length > 0 ? variableInfo.Category + CATEGORY_CHAR : "")
+                        + (obsAttr != null ? FungusConstants.UIPrefixForDeprecated_RichText : "")
+                        + variableInfo.VariableType;
+                    allItems.Add(new FilteredListItem(i, fliStr));
                 }
 
                 i++;

--- a/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
@@ -7,6 +7,7 @@ using System;
 using UnityEditorInternal;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Fungus.EditorUtils
 {
@@ -179,7 +180,9 @@ namespace Fungus.EditorUtils
                 }
             }
 
-            VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(variable.GetType());
+            var varType = variable.GetType();
+
+            VariableInfoAttribute variableInfo = VariableEditor.GetVariableInfo(varType);
             if (variableInfo == null)
             {
                 return;
@@ -232,7 +235,23 @@ namespace Fungus.EditorUtils
 
             variableObject.Update();
 
-            GUI.Label(itemRects[0], variableInfo.VariableType);
+            var obsAttr = varType.GetCustomAttribute<System.ObsoleteAttribute>();
+
+
+            if (obsAttr != null)
+            {
+                var existingGUICol = GUI.color;
+                GUI.color = Color.yellow;
+                GUI.Label(itemRects[0], FungusConstants.UIPrefixForDeprecated + variableInfo.VariableType);
+                GUI.color = existingGUICol;
+            }
+            else
+            {
+                GUI.Label(itemRects[0], variableInfo.VariableType);
+            }
+
+
+
 
             SerializedProperty keyProp = variableObject.FindProperty("key");
             SerializedProperty defaultProp = variableObject.FindProperty("value");

--- a/Assets/Fungus/Scripts/Utils/FungusConstants.cs
+++ b/Assets/Fungus/Scripts/Utils/FungusConstants.cs
@@ -49,6 +49,9 @@ namespace Fungus
 
         public const string FungusAudioMixer = "FungusAudioMixer";
 
+        public const string UIPrefixForDeprecated = "[DEP] ";
+        public const string UIPrefixForDeprecated_RichText = "<color=yellow>" + UIPrefixForDeprecated + "</color>";
+
         #endregion
     }
 }


### PR DESCRIPTION
Can be added to Commands, Variables, and EventHandlers. Resulting in a warning box when using them and showing a yellow [DEP] prefacing them.
Add Obsolete to iTween tween commands that have existing LeanTween alternates

### Description
Closes #858 