### PR TITLE
Add Punch/Wobble effect to speaking character

### DIFF
--- a/Assets/Fungus/Scripts/Commands/ControlStage.cs
+++ b/Assets/Fungus/Scripts/Commands/ControlStage.cs
@@ -23,7 +23,11 @@ namespace Fungus
         /// <summary> Undim all portraits on the stage. </summary>
         UndimAllPortraits,
         /// <summary> Dim all non-speaking portraits on the stage. </summary>
-        DimNonSpeakingPortraits
+        DimNonSpeakingPortraits,
+        /// <summary> Dim all non-speaking portraits on the stage. </summary>
+        FlashSpeakingPortraits,
+        /// <summary> Unflash all portraits on the stage. </summary>
+        UnflashAllPortraits
     }
 
     /// <summary>
@@ -103,6 +107,22 @@ namespace Fungus
             stage.DimPortraits = true;
         }
 
+        protected virtual void UnflashAllPortraits(Stage stage) 
+        {
+            stage.FlashPortraits = false;
+            var charactersOnStage = stage.CharactersOnStage;
+            for (int i = 0; i > charactersOnStage.Count; i++)
+            {
+                var character = charactersOnStage[i];
+                stage.SetFlashed(character, false);
+            }
+        }
+
+        protected virtual void FlashSpeakingPortraits(Stage stage) 
+        {
+            stage.FlashPortraits = true;
+        }
+
         protected virtual void OnComplete() 
         {
             if (waitUntilFinished)
@@ -173,8 +193,14 @@ namespace Fungus
             case (StageDisplayType.UndimAllPortraits):
                 UndimAllPortraits(stage);
                 break;
+            case (StageDisplayType.UnflashAllPortraits):
+                UnflashAllPortraits(stage);
+                break;
             case (StageDisplayType.DimNonSpeakingPortraits):
                 DimNonSpeakingPortraits(stage);
+                break;
+            case (StageDisplayType.FlashSpeakingPortraits):
+                FlashSpeakingPortraits(stage);
                 break;
             }
 

--- a/Assets/Fungus/Scripts/Components/PortraitController.cs
+++ b/Assets/Fungus/Scripts/Components/PortraitController.cs
@@ -520,6 +520,26 @@ namespace Fungus
             LeanTween.color(character.State.portraitImage.rectTransform, targetColor, duration).setEase(stage.FadeEaseType).setRecursive(false);
         }
 
+        /// <summary>
+        /// Sets the punched state of a character on the stage.
+        /// </summary>
+        public virtual void SetFlashed(Character character, bool flashedState)
+        {
+            if (character.State.flashed != flashedState)
+            {
+                return;
+            }
+
+            character.State.flashed = flashedState;
+
+            Color targetColor = flashedState ? stage.DimColor : Color.white;
+
+            // LeanTween doesn't handle 0 duration properly
+            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+
+            LeanTween.scale(character.State.portraitImage.rectTransform, Vector3.zero, duration).setEase(LeanTweenType.punch).setRecursive(false);
+        }
+
         #region Overloads and Helpers
 
         /// <summary>

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -76,25 +76,18 @@ namespace Fungus
 
         protected float startStoryTextWidth; 
         protected float startStoryTextInset;
-
         protected WriterAudio writerAudio;
         protected Writer writer;
         protected CanvasGroup canvasGroup;
-
         protected bool fadeWhenDone = true;
         protected float targetAlpha = 0f;
         protected float fadeCoolDownTimer = 0f;
-
         protected Sprite currentCharacterImage;
-
         // Most recent speaking character
         protected static Character speakingCharacter;
-
         protected StringSubstituter stringSubstituter = new StringSubstituter();
-
 		// Cache active Say Dialogs to avoid expensive scene search
 		protected static List<SayDialog> activeSayDialogs = new List<SayDialog>();
-
 		protected virtual void Awake()
 		{
 			if (!activeSayDialogs.Contains(this))
@@ -308,6 +301,9 @@ namespace Fungus
                         {
                             c.State.portraitImage.color = Color.white;
                         }
+
+
+
                     }
                 }
             }
@@ -369,6 +365,34 @@ namespace Fungus
                         }
                     }
                 }
+
+                speakingCharacter = character;
+
+                // Punch portraits of speaking characters
+                for (int i = 0; i < activeStages.Count; i++)
+                {
+                    var stage = activeStages[i];
+                    if (stage.FlashPortraits)
+                    {
+                        var charactersOnStage = stage.CharactersOnStage;
+                        for (int j = 0; j < charactersOnStage.Count; j++)
+                        {
+                            var c = charactersOnStage[j];
+                            if (prevSpeakingCharacter != speakingCharacter)
+                            {
+                                if (c != null && !c.Equals(speakingCharacter))
+                                {
+                                    stage.SetFlashed(c, true);
+                                }
+                                else
+                                {
+                                    stage.SetFlashed(c, false);
+                                }
+                            }
+                        }
+                    }
+                }
+
 
                 string characterName = character.NameText;
 

--- a/Assets/Fungus/Scripts/Components/Stage.cs
+++ b/Assets/Fungus/Scripts/Components/Stage.cs
@@ -17,6 +17,9 @@ namespace Fungus
         [Tooltip("Canvas object containing the stage positions.")]
         [SerializeField] protected Canvas portraitCanvas;
 
+        [Tooltip("Punch portraits when a character is speaking.")]
+        [SerializeField] protected bool flashPortraits;
+
         [Tooltip("Dim portraits when a character is not speaking.")]
         [SerializeField] protected bool dimPortraits;
 
@@ -93,6 +96,11 @@ namespace Fungus
         /// Canvas object containing the stage positions.
         /// </summary>
         public virtual Canvas PortraitCanvas { get { return portraitCanvas; } }
+
+        /// <summary>
+        /// Punch portraits when a character is speaking.
+        /// </summary>
+        public virtual bool FlashPortraits { get { return flashPortraits; } set { flashPortraits = value; } }
 
         /// <summary>
         /// Dim portraits when a character is not speaking.

--- a/Assets/Fungus/Scripts/Utils/PortraitUtils.cs
+++ b/Assets/Fungus/Scripts/Utils/PortraitUtils.cs
@@ -60,6 +60,7 @@ namespace Fungus
     {
         public bool onScreen;
         public bool dimmed;
+        public bool flashed;
         public DisplayType display;
         public RectTransform position, holder;
         public FacingDirection facing;


### PR DESCRIPTION
Add Punch effect to the speaking character, this can be used together with Dim as well.

The idea came from our tester, as he can't tell who's actually speaking if "Dim" wasn't being used (even though the name of the character was displayed)

### Description
New added feature as shown in the gif below:
![uImpjeIwEC](https://user-images.githubusercontent.com/64100867/94550762-7c54d000-027e-11eb-991a-bbf5e4bef192.gif)

Add new checkbox in Stage setting
![flashportraitFungame](https://user-images.githubusercontent.com/64100867/94550887-b3c37c80-027e-11eb-92af-06454e78adae.PNG)

### What is the current behavior?
This feature is not explicitly available in Fungus

### What is the new behavior?
Adding new Punch tween setting to be part of Fungus's Stage system including ControlStage

### Important Notes
- Add new public bool to PortraitUtils
If this breaks Fungus code standard or if it's not allowed, pls let me know, 
- The name "Flash" displayed in Stage setting because the word "Punch" would confuse users. Obviously, this can be changed.

### Other information
It should not break compatibility.