### PR TITLE
Add Log of Location for Command Execute Exceptions

### DIFF
--- a/Assets/Fungus/Scripts/Components/Block.cs
+++ b/Assets/Fungus/Scripts/Components/Block.cs
@@ -313,6 +313,7 @@ namespace Fungus
                 command.ExecutingIconTimer = Time.realtimeSinceStartup + FungusConstants.ExecutingIconFadeTime;
                 BlockSignals.DoCommandExecute(this, command, i, commandList.Count);
 
+#if UNITY_EDITOR
                 try
                 {
                     command.Execute();
@@ -322,6 +323,9 @@ namespace Fungus
                     Debug.LogError("Rethrowing Exception thrown by:" + command.GetLocationIdentifier());
                     throw;
                 }
+#else
+                command.Execute();
+#endif
 
                 // Wait until the executing command sets another command to jump to via Command.Continue()
                 while (jumpToCommandIndex == -1)

--- a/Assets/Fungus/Scripts/Components/Block.cs
+++ b/Assets/Fungus/Scripts/Components/Block.cs
@@ -312,7 +312,16 @@ namespace Fungus
                 // set it here in case a command starts and finishes execution before the next window update.
                 command.ExecutingIconTimer = Time.realtimeSinceStartup + FungusConstants.ExecutingIconFadeTime;
                 BlockSignals.DoCommandExecute(this, command, i, commandList.Count);
-                command.Execute();
+
+                try
+                {
+                    command.Execute();
+                }
+                catch (Exception)
+                {
+                    Debug.LogError("Rethrowing Exception thrown by:" + command.GetLocationIdentifier());
+                    throw;
+                }
 
                 // Wait until the executing command sets another command to jump to via Command.Continue()
                 while (jumpToCommandIndex == -1)


### PR DESCRIPTION
closes #882

### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Allows for easier tracking down of exceptions caused by Commands within Fungus.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
Fungus allows exceptions to bubble all the way up to unity for capture and log into Unity Console. This is troublesome when there are many Flowcharts, many Blocks or Many similar Commands as it does not identify which command in which block, in which flowchart.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Blocks now catch, exceptions from Command.Execute. LogError their LocationIdentifier to console and rethrow the exception
- This results in 2 exception logs for each command exception but makes them far easier to trace and does not alter the existing paradigm of allowing exceptions to bubble all the way up to Unity.
