### PR TITLE
Add LeanTween Shake alternatives

### DIFF
--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeCameraLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeCameraLean.cs
@@ -1,0 +1,106 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Applies a camera shake effect to the main camera.
+    /// </summary>
+    [CommandInfo("LeanTween",
+                 "Shake Camera",
+                 "Applies a camera shake effect to the main camera.")]
+    [AddComponentMenu("")]
+    public abstract class ShakeCameraLean : Command
+    {
+        [Tooltip("The time in seconds the animation will take to complete")]
+        [SerializeField]
+        protected FloatData _duration = new FloatData(1f);
+
+        [Tooltip("Amount to skake on each axis")]
+        [SerializeField]
+        protected Vector3Data _axisScale;
+
+        [Tooltip("Amount to skake on each axis")]
+        [SerializeField]
+        protected Vector2Data _axisSpeedRange = new Vector2Data(new Vector2(5, 10));
+
+        [Tooltip("Whether to animate in world space or relative to the parent. False by default.")]
+        [SerializeField]
+        protected bool isLocal;
+
+        [Tooltip("The shape of the easing curve applied to the animation")]
+        [SerializeField]
+        protected LeanTweenType easeType = LeanTweenType.linear;
+
+        [Tooltip("Stop any previously LeanTweens on this object before adding this one. Warning; expensive.")]
+        [SerializeField]
+        protected bool stopPreviousTweens = false;
+
+        [Tooltip("Wait until the tween has finished before executing the next command")]
+        [SerializeField]
+        protected bool waitUntilFinished = true;
+
+        [HideInInspector] protected LTDescr ourTween;
+
+        protected virtual void OnTweenComplete()
+        {
+            Continue();
+        }
+
+        public override void OnEnter()
+        {
+            var targetTransform = Camera.main.transform;
+
+
+            if (stopPreviousTweens)
+            {
+                LeanTween.cancel(targetTransform.gameObject);
+            }
+
+            if (isLocal)
+                ourTween = LeanTweenHelpers.ShakePositionLocal(
+                    targetTransform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+            else
+                ourTween = LeanTweenHelpers.ShakePosition(
+                    targetTransform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+
+            ourTween.setEase(easeType);
+
+            if (waitUntilFinished)
+            {
+                if (ourTween != null)
+                {
+                    ourTween.setOnComplete(OnTweenComplete);
+                }
+            }
+            else
+            {
+                Continue();
+            }
+        }
+
+        public override string GetSummary()
+        {
+            return "over " + _duration.Value + " seconds";
+        }
+
+        public override Color GetButtonColor()
+        {
+            return new Color32(233, 163, 180, 255);
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _duration.floatRef ||
+                _axisScale.vector3Ref == variable || _axisSpeedRange.vector2Ref == variable;
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeCameraLean.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeCameraLean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 291ee3a3cd0e2d04aa2a4f619489c303
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs
@@ -1,0 +1,107 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Base class to account for the slight differences between regular leantween command
+    /// and ones that use the shake helpers.
+    /// </summary>
+    [AddComponentMenu("")]
+    public abstract class ShakeLean : Command
+    {
+        [Tooltip("Target game object to apply the Tween to")]
+        [SerializeField]
+        protected GameObjectData _targetObject;
+
+        [Tooltip("The time in seconds the animation will take to complete")]
+        [SerializeField]
+        protected FloatData _duration = new FloatData(1f);
+
+        [Tooltip("Amount to skake on each axis")]
+        [SerializeField]
+        protected Vector3Data _axisScale;
+
+        [Tooltip("Amount to skake on each axis")]
+        [SerializeField]
+        protected Vector2Data _axisSpeedRange = new Vector2Data(new Vector2(5, 10));
+
+        [Tooltip("Whether to animate in world space or relative to the parent. False by default.")]
+        [SerializeField]
+        protected bool isLocal;
+
+        [Tooltip("The shape of the easing curve applied to the animation")]
+        [SerializeField]
+        protected LeanTweenType easeType = LeanTweenType.linear;
+
+        [Tooltip("Stop any previously LeanTweens on this object before adding this one. Warning; expensive.")]
+        [SerializeField]
+        protected bool stopPreviousTweens = false;
+
+        [Tooltip("Wait until the tween has finished before executing the next command")]
+        [SerializeField]
+        protected bool waitUntilFinished = true;
+
+        [HideInInspector] protected LTDescr ourTween;
+
+        protected virtual void OnTweenComplete()
+        {
+            Continue();
+        }
+
+        public override void OnEnter()
+        {
+            if (_targetObject.Value == null)
+            {
+                Continue();
+                return;
+            }
+
+            if (stopPreviousTweens)
+            {
+                LeanTween.cancel(_targetObject.Value);
+            }
+
+            ourTween = ExecuteTween();
+
+            ourTween.setEase(easeType);
+
+            if (waitUntilFinished)
+            {
+                if (ourTween != null)
+                {
+                    ourTween.setOnComplete(OnTweenComplete);
+                }
+            }
+            else
+            {
+                Continue();
+            }
+        }
+
+        public override string GetSummary()
+        {
+            if (_targetObject.Value == null)
+            {
+                return "Error: No target object selected";
+            }
+
+            return _targetObject.Value.name + " over " + _duration.Value + " seconds";
+        }
+
+        public override Color GetButtonColor()
+        {
+            return new Color32(233, 163, 180, 255);
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return variable == _targetObject.gameObjectRef || variable == _duration.floatRef ||
+                _axisScale.vector3Ref == variable || _axisSpeedRange.vector2Ref == variable;
+        }
+
+        public abstract LTDescr ExecuteTween();
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9251c3e3f48c1a743bed428e6308f806
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakePositionLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakePositionLean.cs
@@ -1,0 +1,33 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Impulse style shake of an object's position, using LeanTween internally.
+    /// </summary>
+    [CommandInfo("LeanTween",
+                 "Shake Position",
+                 "Impulse style shake of an object's position, using LeanTween internally.")]
+    [AddComponentMenu("")]
+    public class ShakePositionLean : ShakeLean
+    {
+        public override LTDescr ExecuteTween()
+        {
+            if (isLocal)
+                return LeanTweenHelpers.ShakePositionLocal(
+                    _targetObject.Value.transform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+            else
+                return LeanTweenHelpers.ShakePosition(
+                    _targetObject.Value.transform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakePositionLean.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakePositionLean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e4410bcb98a7d545a7edcb2606706ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeRotationLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeRotationLean.cs
@@ -1,0 +1,33 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Impulse style shake of an object's rotation, using LeanTween internally.
+    /// </summary>
+    [CommandInfo("LeanTween",
+                 "Shake Rotation",
+                 "")]
+    [AddComponentMenu("Impulse style shake of an object's rotation, using LeanTween internally.")]
+    public class ShakeRotationLean : ShakeLean
+    {
+        public override LTDescr ExecuteTween()
+        {
+            if (isLocal)
+                return LeanTweenHelpers.ShakeEulerLocal(
+                    _targetObject.Value.transform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+            else
+                return LeanTweenHelpers.ShakeEuler(
+                    _targetObject.Value.transform,
+                    _axisScale.Value,
+                    _axisSpeedRange.Value,
+                    _duration.Value);
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeRotationLean.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeRotationLean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b5b8b999ab46f44bb71ebe77cf27e09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeScaleLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeScaleLean.cs
@@ -1,0 +1,26 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Impulse style shake of an object's scale, using LeanTween internally.
+    /// </summary>
+    [CommandInfo("LeanTween",
+                 "Shake Scale",
+                 "Impulse style shake of an object's scale, using LeanTween internally.")]
+    [AddComponentMenu("")]
+    public class ShakeScaleLean : ShakeLean
+    {
+        public override LTDescr ExecuteTween()
+        {
+            return LeanTweenHelpers.ShakeScale(
+                _targetObject.Value.transform,
+                _axisScale.Value,
+                _axisSpeedRange.Value,
+                _duration.Value);
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeScaleLean.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeScaleLean.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3caa705d6819f49418c577d412b8f772
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/ShakeCamera.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakeCamera.cs
@@ -13,6 +13,7 @@ namespace Fungus
                  "Shake Camera", 
                  "Applies a camera shake effect to the main camera.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     public class ShakeCamera : Command 
     {
         [Tooltip("Time for camera shake effect to complete")]

--- a/Assets/Fungus/Scripts/Commands/ShakePosition.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakePosition.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Shake Position", 
                  "Randomly shakes a GameObject's position by a diminishing amount over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ShakePosition : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/ShakeRotation.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakeRotation.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Shake Rotation", 
                  "Randomly shakes a GameObject's rotation by a diminishing amount over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ShakeRotation : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Commands/ShakeScale.cs
+++ b/Assets/Fungus/Scripts/Commands/ShakeScale.cs
@@ -14,6 +14,7 @@ namespace Fungus
                  "Shake Scale", 
                  "Randomly shakes a GameObject's rotation by a diminishing amount over time.")]
     [AddComponentMenu("")]
+    [System.Obsolete("Deprecated, consider using the LeanTween based Tween command instead.")]
     [ExecuteInEditMode]
     public class ShakeScale : iTweenCommand
     {

--- a/Assets/Fungus/Scripts/Components/Writer.cs
+++ b/Assets/Fungus/Scripts/Components/Writer.cs
@@ -816,7 +816,7 @@ namespace Fungus
 
             if (go != null)
             {
-                iTween.ShakePosition(go, axis, time);
+                LeanTweenHelpers.ShakePosition(go.transform, axis, new Vector2(30,60), time);
             }
         }
         

--- a/Assets/Fungus/Scripts/Utils/LeanTweenHelpers.cs
+++ b/Assets/Fungus/Scripts/Utils/LeanTweenHelpers.cs
@@ -1,0 +1,106 @@
+﻿// This code is part of the Fungus library (https://github.com/snozbot/fungus)
+// It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
+
+using UnityEngine;
+
+namespace Fungus
+{
+    public static class LeanTweenHelpers
+    {
+        public static readonly AnimationCurve ShakeScaleCurve = new AnimationCurve(
+            new Keyframe(0, 0),
+            new Keyframe(0.05f, 1),
+            new Keyframe(1, 0));
+
+        public static readonly Vector2 DefaultSpeedRange = new Vector2(5, 10);
+
+        private const float PerlinStratingRange = 1000;
+
+        internal static Vector3 PerlinStartingPoint
+        {
+            get
+            {
+                return new Vector3(Random.Range(-PerlinStratingRange, PerlinStratingRange),
+                    Random.Range(-PerlinStratingRange, PerlinStratingRange),
+                    Random.Range(-PerlinStratingRange, PerlinStratingRange));
+            }
+        }
+
+        internal static Vector3 PerlinSpeed(Vector2 speedRange)
+        {
+            return new Vector3(Random.Range(speedRange.x, speedRange.y),
+                Random.Range(speedRange.x, speedRange.y),
+                Random.Range(speedRange.x, speedRange.y));
+        }
+
+        internal static LTDescr Shake(
+            System.Func<Vector3> getStartingValue,
+            System.Action<Vector3> setValue,
+            Transform transform,
+            Vector3 axisScale,
+            Vector2 speedRange,
+            float time)
+        {
+            var startingEuler = getStartingValue();
+            var px = PerlinStartingPoint;
+            var py = PerlinStartingPoint;
+            var psx = PerlinSpeed(speedRange);
+            var psy = PerlinSpeed(speedRange);
+            var lt = LeanTween.value(0, 1, time)
+                .setOnUpdate((float v) =>
+                {
+                    var n = new Vector3(
+                        Mathf.PerlinNoise(px.x + v * psx.x, py.x + v * psy.x),
+                        Mathf.PerlinNoise(px.y + v * psx.y, py.y + v * psy.y),
+                        Mathf.PerlinNoise(px.z + v * psx.z, py.z + v * psy.z));
+                    n *= 2;
+                    n -= Vector3.one;
+                    n.Scale(axisScale);
+                    setValue(startingEuler + n * ShakeScaleCurve.Evaluate(v));
+                })
+                .setOnComplete(() => setValue(startingEuler));
+
+            return lt;
+        }
+
+        public static LTDescr ShakeEuler(Transform transform, Vector3 axisScale, Vector2 speedRange, float time)
+        {
+            return Shake(
+                () => transform.eulerAngles,
+                (x) => transform.eulerAngles = x,
+                transform, axisScale, speedRange, time);
+        }
+
+        public static LTDescr ShakeEulerLocal(Transform transform, Vector3 axisScale, Vector2 speedRange, float time)
+        {
+            return Shake(
+                () => transform.localEulerAngles,
+                (x) => transform.localEulerAngles = x,
+                transform, axisScale, speedRange, time);
+        }
+
+        public static LTDescr ShakePosition(Transform transform, Vector3 axisScale, Vector2 speedRange, float time)
+        {
+            return Shake(
+                () => transform.position,
+                (x) => transform.position = x,
+                transform, axisScale, speedRange, time);
+        }
+
+        public static LTDescr ShakePositionLocal(Transform transform, Vector3 axisScale, Vector2 speedRange, float time)
+        {
+            return Shake(
+                () => transform.localPosition,
+                (x) => transform.localPosition = x,
+                transform, axisScale, speedRange, time);
+        }
+
+        public static LTDescr ShakeScale(Transform transform, Vector3 axisScale, Vector2 speedRange, float time)
+        {
+            return Shake(
+                () => transform.localScale,
+                (x) => transform.localScale = x,
+                transform, axisScale, speedRange, time);
+        }
+    }
+}

--- a/Assets/Fungus/Scripts/Utils/LeanTweenHelpers.cs.meta
+++ b/Assets/Fungus/Scripts/Utils/LeanTweenHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88d7fd752e9de6a4594dcb3fe3f85448
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FungusExamples/LeanTween/LeanTween.unity
+++ b/Assets/FungusExamples/LeanTween/LeanTween.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 9
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -39,30 +39,30 @@ RenderSettings:
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
   m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 12
     m_Resolution: 1
     m_BakeResolution: 50
-    m_TextureWidth: 1024
-    m_TextureHeight: 1024
+    m_AtlasSize: 1024
     m_AO: 0
     m_AOMaxDistance: 1
     m_CompAOExponent: 0
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,17 +77,28 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
-    m_PVRFiltering: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
     m_PVRFilteringGaussRadiusAO: 2
-    m_PVRFilteringAtrousColorSigma: 1
-    m_PVRFilteringAtrousNormalSigma: 1
-    m_PVRFilteringAtrousPositionSigma: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 0
 --- !u!196 &5
 NavMeshSettings:
   serializedVersion: 2
@@ -107,17 +118,19 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    debug:
+      m_Flags: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &131346341
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 131346346}
   - component: {fileID: 131346345}
-  - component: {fileID: 131346344}
   - component: {fileID: 131346343}
   - component: {fileID: 131346342}
   m_Layer: 0
@@ -130,34 +143,36 @@ GameObject:
 --- !u!81 &131346342
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131346341}
   m_Enabled: 1
 --- !u!124 &131346343
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 131346341}
-  m_Enabled: 1
---- !u!92 &131346344
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131346341}
   m_Enabled: 1
 --- !u!20 &131346345
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131346341}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0.019607844}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -179,16 +194,17 @@ Camera:
   m_TargetEye: 3
   m_HDR: 0
   m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!4 &131346346
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131346341}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
@@ -200,9 +216,10 @@ Transform:
 --- !u!1 &470391086
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 470391092}
   - component: {fileID: 470391091}
@@ -220,8 +237,9 @@ GameObject:
 --- !u!114 &470391088
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -229,12 +247,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentBlock: {fileID: 470391089}
+  suppressBlockAutoSelect: 0
   message: StartMoving
 --- !u!114 &470391089
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -255,11 +275,13 @@ MonoBehaviour:
   eventHandler: {fileID: 470391088}
   commandList:
   - {fileID: 470391093}
+  suppressAllAutoSelections: 0
 --- !u!114 &470391090
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -296,15 +318,20 @@ MonoBehaviour:
 --- !u!212 &470391091
 SpriteRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -314,9 +341,11 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
   m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -333,11 +362,15 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!4 &470391092
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.6141, y: -2, z: 0}
@@ -349,8 +382,9 @@ Transform:
 --- !u!114 &470391093
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 470391086}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -381,16 +415,23 @@ MonoBehaviour:
   isLocal: 0
 --- !u!114 &497781872 stripped
 MonoBehaviour:
-  m_PrefabParentObject: {fileID: 11400000, guid: e0d427add844a4d9faf970a3afa07583,
-    type: 2}
-  m_PrefabInternal: {fileID: 1288462056}
+  m_CorrespondingSourceObject: {fileID: 11400000, guid: e0d427add844a4d9faf970a3afa07583,
+    type: 3}
+  m_PrefabInstance: {fileID: 1288462056}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95c387d3e32404bcc91c60318d766bb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &868138990
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 868138994}
   - component: {fileID: 868138993}
@@ -415,6 +456,9 @@ GameObject:
   - component: {fileID: 868139007}
   - component: {fileID: 868139013}
   - component: {fileID: 868139006}
+  - component: {fileID: 868139008}
+  - component: {fileID: 868139010}
+  - component: {fileID: 868139009}
   m_Layer: 0
   m_Name: Flowchart
   m_TagString: Untagged
@@ -425,8 +469,9 @@ GameObject:
 --- !u!114 &868138991
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -458,8 +503,9 @@ MonoBehaviour:
 --- !u!114 &868138992
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -468,8 +514,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   nodeRect:
     serializedVersion: 2
-    x: 164
-    y: 193
+    x: 160
+    y: 200
     width: 120
     height: 40
   tint: {r: 1, g: 1, b: 1, a: 1}
@@ -484,6 +530,9 @@ MonoBehaviour:
   - {fileID: 868139012}
   - {fileID: 868138998}
   - {fileID: 868139017}
+  - {fileID: 868139008}
+  - {fileID: 868139010}
+  - {fileID: 868139009}
   - {fileID: 868138991}
   - {fileID: 868138996}
   - {fileID: 868139015}
@@ -498,11 +547,13 @@ MonoBehaviour:
   - {fileID: 868139013}
   - {fileID: 868139007}
   - {fileID: 868139006}
+  suppressAllAutoSelections: 0
 --- !u!114 &868138993
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -513,7 +564,7 @@ MonoBehaviour:
   scrollPos: {x: 64, y: -8}
   variablesScrollPos: {x: 0, y: 0}
   variablesExpanded: 1
-  blockViewHeight: 400
+  blockViewHeight: 688
   zoom: 1
   scrollViewRect:
     serializedVersion: 2
@@ -526,7 +577,8 @@ MonoBehaviour:
   variables: []
   description: 'This scene shows how to use the iTween commands
 
-    to apply simple animation effects to objects'
+    to apply simple
+    animation effects to objects'
   stepPause: 0
   colorCommands: 1
   hideComponents: 1
@@ -539,8 +591,9 @@ MonoBehaviour:
 --- !u!4 &868138994
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -552,8 +605,9 @@ Transform:
 --- !u!114 &868138995
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -569,11 +623,16 @@ MonoBehaviour:
   fadeColor: {r: 0, g: 0, b: 0, a: 1}
   fadeTexture: {fileID: 0}
   targetCamera: {fileID: 0}
+  fadeTweenType: 4
+  orthoSizeTweenType: 4
+  posTweenType: 4
+  rotTweenType: 4
 --- !u!114 &868138996
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -605,8 +664,9 @@ MonoBehaviour:
 --- !u!114 &868138997
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -637,8 +697,9 @@ MonoBehaviour:
 --- !u!114 &868138998
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -669,8 +730,9 @@ MonoBehaviour:
 --- !u!114 &868138999
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -703,8 +765,9 @@ MonoBehaviour:
 --- !u!114 &868139000
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -737,8 +800,9 @@ MonoBehaviour:
 --- !u!114 &868139001
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -769,8 +833,9 @@ MonoBehaviour:
 --- !u!114 &868139002
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -801,8 +866,9 @@ MonoBehaviour:
 --- !u!114 &868139003
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -833,8 +899,9 @@ MonoBehaviour:
 --- !u!114 &868139004
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -867,8 +934,9 @@ MonoBehaviour:
 --- !u!114 &868139005
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -900,8 +968,9 @@ MonoBehaviour:
 --- !u!114 &868139006
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -934,8 +1003,9 @@ MonoBehaviour:
 --- !u!114 &868139007
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -965,11 +1035,102 @@ MonoBehaviour:
     vector3Val: {x: 0, y: 0, z: 0}
   isLocal: 0
   rotateMode: 1
+--- !u!114 &868139008
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868138990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e4410bcb98a7d545a7edcb2606706ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 41
+  indentLevel: 0
+  _targetObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1090256565}
+  _duration:
+    floatRef: {fileID: 0}
+    floatVal: 1
+  _axisScale:
+    vector3Ref: {fileID: 0}
+    vector3Val: {x: 1, y: 1, z: 1}
+  _axisSpeedRange:
+    vector2Ref: {fileID: 0}
+    vector2Val: {x: 20, y: 50}
+  isLocal: 0
+  easeType: 4
+  stopPreviousTweens: 0
+  waitUntilFinished: 1
+--- !u!114 &868139009
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868138990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3caa705d6819f49418c577d412b8f772, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 43
+  indentLevel: 0
+  _targetObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1955612099}
+  _duration:
+    floatRef: {fileID: 0}
+    floatVal: 1
+  _axisScale:
+    vector3Ref: {fileID: 0}
+    vector3Val: {x: 1, y: 1, z: 0}
+  _axisSpeedRange:
+    vector2Ref: {fileID: 0}
+    vector2Val: {x: 5, y: 10}
+  isLocal: 0
+  easeType: 1
+  stopPreviousTweens: 0
+  waitUntilFinished: 1
+--- !u!114 &868139010
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868138990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b5b8b999ab46f44bb71ebe77cf27e09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemId: 42
+  indentLevel: 0
+  _targetObject:
+    gameObjectRef: {fileID: 0}
+    gameObjectVal: {fileID: 1621124268}
+  _duration:
+    floatRef: {fileID: 0}
+    floatVal: 1
+  _axisScale:
+    vector3Ref: {fileID: 0}
+    vector3Val: {x: 0, y: 0, z: 50}
+  _axisSpeedRange:
+    vector2Ref: {fileID: 0}
+    vector2Val: {x: 5, y: 10}
+  isLocal: 0
+  easeType: 1
+  stopPreviousTweens: 0
+  waitUntilFinished: 1
 --- !u!114 &868139011
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1001,8 +1162,9 @@ MonoBehaviour:
 --- !u!114 &868139012
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1035,8 +1197,9 @@ MonoBehaviour:
 --- !u!114 &868139013
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1069,8 +1232,9 @@ MonoBehaviour:
 --- !u!114 &868139015
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1102,8 +1266,9 @@ MonoBehaviour:
 --- !u!114 &868139016
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1111,12 +1276,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentBlock: {fileID: 868138992}
+  suppressBlockAutoSelect: 0
   waitForFrames: 1
 --- !u!114 &868139017
 MonoBehaviour:
   m_ObjectHideFlags: 2
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 868138990}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -1133,9 +1300,10 @@ MonoBehaviour:
 --- !u!1 &1090256565
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1090256567}
   - component: {fileID: 1090256566}
@@ -1149,15 +1317,20 @@ GameObject:
 --- !u!212 &1090256566
 SpriteRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1090256565}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1167,9 +1340,11 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
   m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -1186,11 +1361,15 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!4 &1090256567
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1090256565}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2.0274, y: -0.084476, z: 0}
@@ -1200,57 +1379,57 @@ Transform:
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1288462056
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 11400000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
+    - target: {fileID: 11400000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
       propertyPath: viewSize
       value: 3.39926291
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: e0d427add844a4d9faf970a3afa07583, type: 2}
-  m_IsPrefabParent: 0
+  m_SourcePrefab: {fileID: 100100000, guid: e0d427add844a4d9faf970a3afa07583, type: 3}
 --- !u!1 &1621124268
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1621124270}
   - component: {fileID: 1621124269}
@@ -1264,15 +1443,20 @@ GameObject:
 --- !u!212 &1621124269
 SpriteRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1621124268}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1282,9 +1466,11 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
   m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -1301,11 +1487,15 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!4 &1621124270
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1621124268}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.1541, y: -0.042237, z: 0}
@@ -1317,9 +1507,10 @@ Transform:
 --- !u!1 &1749438602
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1749438606}
   - component: {fileID: 1749438605}
@@ -1335,24 +1526,26 @@ GameObject:
 --- !u!114 &1749438603
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1749438602}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1997211142, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 2d49b7c1bcd2e07499844da127be038d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_ForceModuleActive: 0
 --- !u!114 &1749438604
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1749438602}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_HorizontalAxis: Horizontal
@@ -1365,12 +1558,13 @@ MonoBehaviour:
 --- !u!114 &1749438605
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1749438602}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
@@ -1379,8 +1573,9 @@ MonoBehaviour:
 --- !u!4 &1749438606
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1749438602}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -1392,9 +1587,10 @@ Transform:
 --- !u!1 &1955612099
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1955612100}
   - component: {fileID: 1955612101}
@@ -1408,8 +1604,9 @@ GameObject:
 --- !u!4 &1955612100
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1955612099}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.12, y: 2.33, z: 0}
@@ -1421,15 +1618,20 @@ Transform:
 --- !u!212 &1955612101
 SpriteRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1955612099}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -1439,9 +1641,11 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
   m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
@@ -1458,12 +1662,16 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1971204863
 GameObject:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1971204865}
   - component: {fileID: 1971204864}
@@ -1477,20 +1685,22 @@ GameObject:
 --- !u!114 &1971204864
 MonoBehaviour:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971204863}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 61dddfdc5e0e44ca298d8f46f7f5a915, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  selectedFlowchart: {fileID: 0}
+  selectedFlowchart: {fileID: 868138993}
 --- !u!4 &1971204865
 Transform:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971204863}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
Replace Fungus' internal use of iTween for shakes with a LeanTween based alternative.
Add LeanTween based Shake alternates for all iTween shake commands and mark them as Deprecated.
Add Shakes to LeanTween FungusExample

### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Follows #853, Seeks to remove all remaining internal use of iTween directly by Fungus.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
Shakes used iTween shake internally.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- No change to user. Fungus internally uses a LeanTween based alternate for shakes.
- LeanTween based Shake commands have been added and the existing iTween shake commands have been marked as deprecated

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation (regeneration of auto gen doco)
- My change modifies existing FungusExamples