### PR TITLE
Add EventHandler Error Box

### DIFF
--- a/Assets/Fungus/Scripts/Editor/BlockEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockEditor.cs
@@ -183,6 +183,9 @@ namespace Fungus.EditorUtils
                     command.ParentBlock = block;
                 }
 
+
+                EditorGUILayout.Space();
+
                 commandListAdaptor.DrawCommandList();
 
                 // EventType.contextClick doesn't register since we moved the Block Editor to be inside

--- a/Assets/Fungus/Scripts/Editor/CommandEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandEditor.cs
@@ -139,7 +139,7 @@ namespace Fungus.EditorUtils
 
             // Display help text
             CommandInfoAttribute infoAttr = CommandEditor.GetCommandInfo(t.GetType());
-            if (infoAttr != null)
+            if (infoAttr != null && !FungusEditorPreferences.suppressHelpBoxes)
             {
                 EditorGUILayout.HelpBox(infoAttr.HelpText, MessageType.Info, true);
             }

--- a/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
@@ -42,7 +42,10 @@ namespace Fungus.EditorUtils
 
             if (block.CommandList.Count == 0)
             {
-                EditorGUILayout.HelpBox("Press the + button below to add a command to the list.", MessageType.Info);
+                if (!FungusEditorPreferences.suppressHelpBoxes)
+                {
+                    EditorGUILayout.HelpBox("Press the + button below to add a command to the list.", MessageType.Info); 
+                }
             }
             else
             {

--- a/Assets/Fungus/Scripts/Editor/EventHandlerEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/EventHandlerEditor.cs
@@ -7,8 +7,8 @@ using UnityEngine;
 
 namespace Fungus.EditorUtils
 {
-    [CustomEditor (typeof(EventHandler), true)]
-    public class EventHandlerEditor : Editor 
+    [CustomEditor(typeof(EventHandler), true)]
+    public class EventHandlerEditor : Editor
     {
         protected virtual void DrawProperties()
         {
@@ -40,7 +40,7 @@ namespace Fungus.EditorUtils
                 EditorGUILayout.HelpBox(info.HelpText, MessageType.Info);
             }
         }
-        
+
         #region Public members
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Fungus.EditorUtils
                     return eventHandlerInfoAttr;
                 }
             }
-            
+
             return null;
         }
 
@@ -75,7 +75,20 @@ namespace Fungus.EditorUtils
             }
 
             DrawProperties();
-            DrawHelpBox();
+
+            var summary = (target as EventHandler).GetSummary();
+
+            if (!string.IsNullOrEmpty(summary))
+            {
+                EditorGUILayout.HelpBox(summary, summary.StartsWith("Error:") ? MessageType.Error : MessageType.Info, true);
+            }
+
+
+            if (!FungusEditorPreferences.suppressHelpBoxes)
+            {
+                EditorGUILayout.Space();
+                DrawHelpBox();
+            }
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
+++ b/Assets/Fungus/Scripts/Editor/FungusEditorPreferences.cs
@@ -24,12 +24,14 @@ namespace Fungus
             private const string USE_GRID_SNAP = "useGridSnap";
             private const string COMMAND_LIST_ITEM_TINT = "commandListTint";
             private const string FLOWCHART_WINDIOW_BLOCK_TINT = "flowchartWindowBlockTint";
+            private const string SUPPRESS_HELP_BOXES = "suppressHelpBoxes";
 
             public static bool hideMushroomInHierarchy;
             public static bool useLegacyMenus;
             public static bool useGridSnap;
             public static Color commandListTint = Color.white;
             public static Color flowchatBlockTint = Color.white;
+            public static bool suppressHelpBoxes = false;
 
             static FungusEditorPreferences()
             {
@@ -72,6 +74,7 @@ namespace Fungus
                 useGridSnap = EditorGUILayout.Toggle(new GUIContent("Grid Snap", "Align and Snap block positions and widths in the flowchart window to the grid"), useGridSnap);
                 flowchatBlockTint = EditorGUILayout.ColorField(new GUIContent("Flowchart Window Block Tint", "Custom tint used on the Block icons in the Flowchart Window. Default is white."), flowchatBlockTint);
                 commandListTint = EditorGUILayout.ColorField(new GUIContent("Command List Tint", "Custom tint used on the Command List in the Block Inspector. Default is white."), commandListTint);
+                suppressHelpBoxes = EditorGUILayout.Toggle(new GUIContent("Hide Help Boxes", "Hides the Default Help boxes shown in in Block inspector for EventHandlers and Commands."), suppressHelpBoxes);
 
                 EditorGUILayout.Space();
                 //ideally if any are null, but typically it is all or nothing that have broken links due to version changes or moving files external to Unity
@@ -127,6 +130,7 @@ namespace Fungus
                     EditorPrefs.SetString(COMMAND_LIST_ITEM_TINT, colAsString); 
                     colAsString = "#" + ColorUtility.ToHtmlStringRGBA(flowchatBlockTint);
                     EditorPrefs.SetString(FLOWCHART_WINDIOW_BLOCK_TINT, colAsString);
+                    EditorPrefs.SetBool(SUPPRESS_HELP_BOXES, suppressHelpBoxes);
                 }
             }
 
@@ -144,6 +148,7 @@ namespace Fungus
                 {
                     flowchatBlockTint = col;
                 }
+                suppressHelpBoxes = EditorPrefs.GetBool(SUPPRESS_HELP_BOXES, false);
                 prefsLoaded = true;
             }
         }

--- a/Assets/Fungus/Scripts/EventHandlers/ButtonClicked.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/ButtonClicked.cs
@@ -40,7 +40,7 @@ namespace Fungus
                 return targetButton.name;
             }
 
-            return "None";
+            return "Error: no targetButton set.";
         }
 
         #endregion

--- a/Assets/Fungus/Scripts/EventHandlers/DragCancelled.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragCancelled.cs
@@ -2,6 +2,7 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Fungus
@@ -92,6 +93,11 @@ namespace Fungus
 
         public override string GetSummary()
         {
+            if (draggableObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no draggable objects assigned.";
+            }
+
             string summary = "Draggable: ";
             if (this.draggableObjects != null && this.draggableObjects.Count != 0)
             {
@@ -102,12 +108,8 @@ namespace Fungus
                         summary += draggableObjects[i].name + ",";
                     }
                 }
-                return summary;
             }
-            else
-            {
-                return "None";
-            }
+            return summary;
         }
 
         #endregion Public members

--- a/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragCompleted.cs
@@ -2,6 +2,7 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Fungus
@@ -211,6 +212,15 @@ namespace Fungus
 
         public override string GetSummary()
         {
+            if (draggableObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no draggable objects assigned.";
+            }
+            if (targetObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no target objects assigned.";
+            }
+
             string summary = "Draggable: ";
             if (this.draggableObjects != null && this.draggableObjects.Count != 0)
             {
@@ -233,11 +243,6 @@ namespace Fungus
                         summary += targetObjects[i].name + ",";
                     }
                 }
-            }
-
-            if (summary.Length == 0)
-            {
-                return "None";
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/EventHandlers/DragEntered.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragEntered.cs
@@ -2,6 +2,7 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Fungus
@@ -135,6 +136,15 @@ namespace Fungus
 
         public override string GetSummary()
         {
+            if (draggableObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no draggable objects assigned.";
+            }
+            if (targetObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no target objects assigned.";
+            }
+
             string summary = "Draggable: ";
             if (this.draggableObjects != null && this.draggableObjects.Count != 0)
             {
@@ -157,11 +167,6 @@ namespace Fungus
                         summary += targetObjects[i].name + ",";
                     }
                 }
-            }
-
-            if (summary.Length == 0)
-            {
-                return "None";
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/EventHandlers/DragExited.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragExited.cs
@@ -2,6 +2,7 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Fungus
@@ -135,6 +136,15 @@ namespace Fungus
 
         public override string GetSummary()
         {
+            if (draggableObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no draggable objects assigned.";
+            }
+            if (targetObjects.Count(x => x != null) == 0)
+            {
+                return "Error: no target objects assigned.";
+            }
+
             string summary = "Draggable: ";
             if (this.draggableObjects != null && this.draggableObjects.Count != 0)
             {
@@ -157,11 +167,6 @@ namespace Fungus
                         summary += targetObjects[i].name + ",";
                     }
                 }
-            }
-
-            if (summary.Length == 0)
-            {
-                return "None";
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/EventHandlers/DragStarted.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/DragStarted.cs
@@ -2,6 +2,7 @@
 // It is released for free under the MIT open source license (https://github.com/snozbot/fungus/blob/master/LICENSE)
 
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Fungus
@@ -94,6 +95,11 @@ namespace Fungus
 
         public override string GetSummary()
         {
+            if(draggableObjects.Count(x=> x != null) == 0)
+            {
+                return "Error: no draggable objects assigned.";
+            }
+
             string summary = "Draggable: ";
             if (this.draggableObjects != null && this.draggableObjects.Count != 0)
             {
@@ -104,11 +110,6 @@ namespace Fungus
                         summary += draggableObjects[i].name + ",";
                     }
                 }
-            }
-
-            if (summary.Length == 0)
-            {
-                return "None";
             }
 
             return summary;

--- a/Assets/Fungus/Scripts/EventHandlers/EndEdit.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/EndEdit.cs
@@ -37,7 +37,7 @@ namespace Fungus
                 return targetInputField.name;
             }
 
-            return "None";
+            return "Error: no targetInputField set.";
         }
 
         #endregion

--- a/Assets/Fungus/Scripts/EventHandlers/KeyPressed.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/KeyPressed.cs
@@ -57,14 +57,5 @@ namespace Fungus
                 break;
             }
         }
-
-        #region Public members
-
-        public override string GetSummary()
-        {
-            return keyCode.ToString();
-        }
-
-        #endregion
     }
 }

--- a/Assets/Fungus/Scripts/EventHandlers/ObjectClicked.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/ObjectClicked.cs
@@ -94,7 +94,7 @@ namespace Fungus
                 return clickableObject.name;
             }
 
-            return "None";
+            return "Error: no clickableObject set.";
         }
 
         #endregion

--- a/Assets/Fungus/Scripts/EventHandlers/SliderChanged.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/SliderChanged.cs
@@ -47,7 +47,7 @@ namespace Fungus
                 return targetSlider.name;
             }
 
-            return "None";
+            return "Error: no targetSlider set.";
         }
     }
 }

--- a/Assets/Fungus/Scripts/EventHandlers/ToggleChanged.cs
+++ b/Assets/Fungus/Scripts/EventHandlers/ToggleChanged.cs
@@ -49,7 +49,7 @@ namespace Fungus
                 return targetToggle.name;
             }
 
-            return "None";
+            return "Error: No targetToggle set.";
         }
 
         #endregion


### PR DESCRIPTION
EventHandlers GetSummary is now shown in the inspector.
Add editor pref to hide eventhandler and command info helpboxes

closes #834 

### Description
EventHandlers have a GetSummary much like a Command, but it was mostly unused.

### What is the current behavior?
GetSummary was not used.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- EventHandlers returning content in GetSummary are shown in a helpbox, If returning Error: that box is an error box.
- This also adds the ability to toggle off the default HelpBoxes for EventHandlers and Commands in the block inspector, this is found in the FungusPreferences.

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation.
  - Manually update to the EventHandle summary.

### Other information
Existing EventHandlers have had 