### PR TITLE
Add info to logerror for InvokeMethod Awake

### DIFF
--- a/Assets/Fungus/Scripts/Commands/FromString.cs
+++ b/Assets/Fungus/Scripts/Commands/FromString.cs
@@ -26,15 +26,7 @@ namespace Fungus
         {
             if (sourceString != null && outValue != null)
             {
-                double asDouble = 0;
-                try
-                {
-                    asDouble = System.Convert.ToDouble(sourceString.Value, System.Globalization.CultureInfo.CurrentCulture);
-                }
-                catch (System.Exception)
-                {
-                    Debug.LogWarning("Failed to parse as number: " + sourceString.Value);
-                }
+                double asDouble = System.Convert.ToDouble(sourceString.Value, System.Globalization.CultureInfo.CurrentCulture);
 
                 IntegerVariable intOutVar = outValue as IntegerVariable;
                 if (intOutVar != null)

--- a/Assets/Fungus/Scripts/Commands/SetCollider.cs
+++ b/Assets/Fungus/Scripts/Commands/SetCollider.cs
@@ -56,15 +56,7 @@ namespace Fungus
                 SetColliderActive(go);
             }
 
-            GameObject[] taggedObjects = null;
-            try
-            {
-                taggedObjects = GameObject.FindGameObjectsWithTag(targetTag);
-            }
-            catch
-            {
-                // The tag has not been declared in this scene
-            }
+            var taggedObjects = GameObject.FindGameObjectsWithTag(targetTag);
 
             if (taggedObjects != null)
             {

--- a/Assets/Fungus/Scripts/Utils/EventDispatcher.cs
+++ b/Assets/Fungus/Scripts/Utils/EventDispatcher.cs
@@ -114,18 +114,7 @@ namespace Fungus
             for(int i = 0; i < list.Count; ++i)
             {
                 var callback = list[i] as TypedDelegate<T>;
-
-                if(callback != null)
-                {
-                    try
-                    {
-                        callback(evt);
-                    }
-                    catch(Exception gotcha)
-                    {
-                        Log(gotcha.Message);
-                    }
-                }
+                callback?.Invoke(evt);
             }
         }
 


### PR DESCRIPTION
Remove bespoke exception handling in cases where block command catch can do it better.

### Description
See #882 

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
The Awake tries to catch and logbut its info is not overly helpful.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- the awake and onenter of the InvokeMethod will now both result in a rethrow and a logerror with the location information
- other commands with custom try catch inside OnEnter have been removed in favour of calling block handling it.