### PR TITLE
Added object toggling to LeanTween and TweenUI

### DIFF
--- a/Assets/Fungus/Scripts/Commands/LeanTween/BaseLeanTweenCommand.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/BaseLeanTweenCommand.cs
@@ -53,6 +53,9 @@ namespace Fungus
         [SerializeField]
         protected bool waitUntilFinished = true;
 
+        [Tooltip("Disable objects on finished.")]
+        [SerializeField] protected bool disableOnFinished = false;
+
 
         [HideInInspector] protected LTDescr ourTween;
 
@@ -77,11 +80,21 @@ namespace Fungus
                 LeanTween.cancel(_targetObject.Value);
             }
 
+            _targetObject.Value.SetActive(true); //enable object if disabled; no point in tweening a disabled object.
+
             ourTween = ExecuteTween();
 
             ourTween.setEase(easeType)
                     .setRepeat(repeats)
                     .setLoopType(loopType);
+
+            if (disableOnFinished)
+            {
+                if (ourTween != null)
+                {
+                    Invoke(nameof(DisableObject), _duration);
+                }
+            }
 
             if (waitUntilFinished)
             {
@@ -94,6 +107,11 @@ namespace Fungus
             {
                 Continue();
             }
+        }
+
+        protected virtual void DisableObject()
+        {
+            _targetObject.gameObjectVal.SetActive(false);
         }
 
         public abstract LTDescr ExecuteTween();

--- a/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs
+++ b/Assets/Fungus/Scripts/Commands/LeanTween/ShakeLean.cs
@@ -44,6 +44,9 @@ namespace Fungus
         [SerializeField]
         protected bool waitUntilFinished = true;
 
+        [Tooltip("Disable target object when tween is finished finished.")]
+        [SerializeField] protected bool disableOnFinished = false;
+
         [HideInInspector] protected LTDescr ourTween;
 
         protected virtual void OnTweenComplete()
@@ -64,9 +67,19 @@ namespace Fungus
                 LeanTween.cancel(_targetObject.Value);
             }
 
+            _targetObject.Value.SetActive(true); //enable object if disabled; no point in tweening a disabled object.
+
             ourTween = ExecuteTween();
 
             ourTween.setEase(easeType);
+
+            if (disableOnFinished)
+            {
+                if(ourTween != null)
+                {
+                    Invoke(nameof(DisableObject), _duration);
+                }
+            }
 
             if (waitUntilFinished)
             {
@@ -79,6 +92,11 @@ namespace Fungus
             {
                 Continue();
             }
+        }
+
+        protected virtual void DisableObject()
+        {
+            _targetObject.gameObjectVal.SetActive(false);
         }
 
         public override string GetSummary()

--- a/Assets/Fungus/Scripts/Commands/TweenUI.cs
+++ b/Assets/Fungus/Scripts/Commands/TweenUI.cs
@@ -24,6 +24,9 @@ namespace Fungus
         [Tooltip("Time for the tween to complete")]
         [SerializeField] protected FloatData duration = new FloatData(1f);
 
+        [Tooltip("Disable target objects when tween is finished finished.")]
+        [SerializeField] protected BooleanData disableOnFinished = new BooleanData(false);
+
         protected virtual void ApplyTween()
         {
             for (int i = 0; i < targetObjects.Count; i++)
@@ -33,12 +36,18 @@ namespace Fungus
                 {
                     continue;
                 }
+                targetObject.SetActive(true); //enable object if disabled; no point in tweening a disabled object.
                 ApplyTween(targetObject);
             }
 
             if (waitUntilFinished)
             {
                 LeanTween.value(gameObject, 0f, 1f, duration).setOnComplete(OnComplete);
+            }
+
+            if (disableOnFinished)
+            {
+                Invoke(nameof(DisableObjects), duration);
             }
         }
 
@@ -47,6 +56,14 @@ namespace Fungus
         protected virtual void OnComplete()
         {
             Continue();
+        }
+
+        void DisableObjects()
+        {
+            foreach(GameObject go in targetObjects)
+            {
+                go.SetActive(false);
+            }
         }
 
         protected virtual string GetSummaryValue()
@@ -134,7 +151,7 @@ namespace Fungus
 
         public override bool HasReference(Variable variable)
         {
-            return waitUntilFinished.booleanRef == variable || duration.floatRef == variable || base.HasReference(variable);
+            return waitUntilFinished.booleanRef == variable || disableOnFinished.booleanRef == variable || duration.floatRef == variable || base.HasReference(variable);
         }
 
         #endregion

--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -45,6 +45,9 @@ namespace Fungus
         [Tooltip("Sound effect to play on user input (e.g. a click)")]
         [SerializeField] protected AudioClip inputSound;
 
+        [Tooltip("Lerp voice effect while playing. Enabled results in smoother volume transitions between different write sounds. Disable to keep writer volume constant.")]
+        [SerializeField] protected bool lerpWriterVolume = true;
+
         protected float targetVolume = 0f;
 
         // When true, a beep will be played on every written character glyph
@@ -219,8 +222,17 @@ namespace Fungus
 
         protected virtual void Update()
         {
-            if(lastUsedAudioSource != null)
-                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+            if (lastUsedAudioSource != null)
+            {
+                if (lerpWriterVolume)
+                {
+                    lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+                }
+                else
+                {
+                    lastUsedAudioSource.volume = targetVolume;
+                }
+            }
         }
 
         #region IWriterListener implementation

--- a/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
@@ -17,6 +17,7 @@ namespace Fungus.EditorUtils
         protected SerializedProperty soundEffectProp;
         protected SerializedProperty inputSoundProp;
         protected SerializedProperty useLegacyAudioLogicProp;
+        protected SerializedProperty lerpAudioProp;
 
         protected virtual void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace Fungus.EditorUtils
             beepSoundsProp = serializedObject.FindProperty("beepSounds");
             soundEffectProp = serializedObject.FindProperty("soundEffect");
             useLegacyAudioLogicProp = serializedObject.FindProperty("useLegacyAudioLogic");
+            lerpAudioProp = serializedObject.FindProperty("lerpWriterVolume");
         }
 
         public override void OnInspectorGUI() 
@@ -37,6 +39,7 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(volumeProp);
             EditorGUILayout.PropertyField(loopProp);
             EditorGUILayout.PropertyField(useLegacyAudioLogicProp);
+            EditorGUILayout.PropertyField(lerpAudioProp);
             if (useLegacyAudioLogicProp.boolValue)
             {
                 EditorGUILayout.PropertyField(targetAudioSourceProp);


### PR DESCRIPTION
### Description
Added a Disable On Finished toggle (disabled by default) that, if enabled, disables the target objects of LeanTween and TweenUI commands once the tween is finished. 

Tween commands also enable the target objects before starting the tween. This does not have a way to disable at this time since there are very few cases where tweening a disabled object are viable.

Disable On Finished uses an Invoke to work, meaning any cancel invokes and Stop Tween commands will prevent the command from disabling the target object.

### What is the current behavior?
- When calling a LeanTween/TweenUI command, the object is not disabled when the tween is finished. 
- When calling a LeanTween/TweenUI command, if the object is disabled from a prior script or event, the object will remain disabled during the Tween.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- If Disable On Finished is enabled, the target objects will be disabled at the end of the tween duration.
- If the target objects are disabled, they are enabled before starting the tween command; there is no point tweening a disabled object and it's possible that it was disabled by another tween.

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation
     - Possibly. A tooltip has been added to the boolean, but information on CancelInvoke() and StopTween() calls as well as information that tweens will enable the target objects could prove useful.
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.
elegible to be shown; others are disabled. (the new change will enable the objects anyway regardless of their prior state)

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
**Important:** because I did a silly, this PR includes changes from PR #934 which contains an optional boolean to Writer Audio. When merging this branch, 939 can be deleted as this already contains it. 

The changes will affect the following scenarios:
- Manually assigning target object states based on the fact that they need to be manually toggled before and after the tween. (a Set Active = false command after a tween will no longer be necessary)
- Tween commands that assume unneeded objects or certain objects in the command are disabled will no longer work as the tween command will enable the object anyway. This has niche affects, but could prove to have issues to those who have (for example) multiple characters speaking on a stage, but the player only has certain characters that are 

This change was prompted by [this discussion on Discord](https://discord.com/channels/539378910085775361/539378910085775363/797868597379989514)

<!-- Any other information that is important to this PR such as screenshots, gifs, video of before and after the change are always great -->



![Screenshot_46](https://user-images.githubusercontent.com/31874317/104141306-a046a800-537b-11eb-8b0d-ae841914032c.png)
![Screenshot_47](https://user-images.githubusercontent.com/31874317/104141307-a0df3e80-537b-11eb-801e-30cc6129a558.png)