### PR TITLE
Fix Portrait Dim Issue (Temporary workaround!)

### DIFF
--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -353,10 +353,13 @@ namespace Fungus
                     if (stage.DimPortraits)
                     {
                         //Make sure portraitImage.color is white
-                        if(!speakingCharacter.State.dimmed)
+                        if(speakingCharacter.State.portraitImage != null)
                         {
-                            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
-                            LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                            if(!speakingCharacter.State.dimmed)
+                            {
+                                float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+                                LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                            }
                         }
                         var charactersOnStage = stage.CharactersOnStage;
                         for (int j = 0; j < charactersOnStage.Count; j++)

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -375,14 +375,14 @@ namespace Fungus
                             {
                                 if(c.State.dimmed == false && !c.State.portraitImage.color.Equals(Color.white))
                                 {
-                                    if(c == speakingCharacter && speakingCharacter.State.portraitImage != null)
+                                    if(c.Equals(speakingCharacter))
                                     {
                                         LeanTween.color(c.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
                                     }
                                 }
                                 if(c.State.dimmed == true && !c.State.portraitImage.color.Equals(stage.DimColor))
                                 {
-                                    if(c == prevSpeakingCharacter && prevSpeakingCharacter.State.portraitImage != null)
+                                    if(c.Equals(prevSpeakingCharacter))
                                     {
                                         LeanTween.color(c.State.portraitImage.rectTransform, stage.DimColor, duration).setEase(stage.FadeEaseType).setRecursive(false);
                                     }

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -348,17 +348,14 @@ namespace Fungus
                 var activeStages = Stage.ActiveStages;
                 for (int i = 0; i < activeStages.Count; i++)
                 {
-                    //Make sure portraitImage.color is white
-                    if(speakingCharacter != null)
-                    {
-                        if(!speakingCharacter.State.dimmed)
-                        {
-                            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
-                            LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
-                        }
-                    }
-
                     var stage = activeStages[i];
+                    //Make sure portraitImage.color is white
+                    if(!speakingCharacter.State.dimmed)
+                    {
+                        float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+                        LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                    }
+                    
                     if (stage.DimPortraits)
                     {
                         var charactersOnStage = stage.CharactersOnStage;

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -348,6 +348,16 @@ namespace Fungus
                 var activeStages = Stage.ActiveStages;
                 for (int i = 0; i < activeStages.Count; i++)
                 {
+                    //Make sure portraitImage.color is white
+                    if(speakingCharacter != null)
+                    {
+                        if(speakingCharacter.State.portraitImage.color != Color.white)
+                        {
+                            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+                            LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                        }
+                    }
+
                     var stage = activeStages[i];
                     if (stage.DimPortraits)
                     {

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -369,6 +369,8 @@ namespace Fungus
                             }
 
                             //Dim issue workaround. Temporary solution until it completely fixed
+                            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+                            
                             if(c != null && c.State.dimmed == false && c.State.portraitImage.color != Color.white)
                             {
                                 if(c == speakingCharacter)

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -371,18 +371,21 @@ namespace Fungus
                             //Dim issue workaround. Temporary solution until it completely fixed
                             float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
                             
-                            if(c != null && c.State.dimmed == false && c.State.portraitImage.color != Color.white)
+                            if(c.State.portraitImage != null && c != null)
                             {
-                                if(c == speakingCharacter)
+                                if(c.State.dimmed == false && !c.State.portraitImage.color.Equals(Color.white))
                                 {
-                                    LeanTween.color(c.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                                    if(c == speakingCharacter && speakingCharacter.State.portraitImage != null)
+                                    {
+                                        LeanTween.color(c.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                                    }
                                 }
-                            }
-                            if(c != null && c.State.dimmed == true && c.State.portraitImage.color != stage.DimColor)
-                            {
-                                if(c == prevSpeakingCharacter)
+                                if(c.State.dimmed == true && !c.State.portraitImage.color.Equals(stage.DimColor))
                                 {
-                                    LeanTween.color(c.State.portraitImage.rectTransform, stage.DimColor, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                                    if(c == prevSpeakingCharacter && prevSpeakingCharacter.State.portraitImage != null)
+                                    {
+                                        LeanTween.color(c.State.portraitImage.rectTransform, stage.DimColor, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                                    }
                                 }
                             }
                         }

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -351,7 +351,7 @@ namespace Fungus
                     //Make sure portraitImage.color is white
                     if(speakingCharacter != null)
                     {
-                        if(speakingCharacter.State.portraitImage.color != Color.white)
+                        if(!speakingCharacter.State.dimmed)
                         {
                             float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
                             LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -349,15 +349,15 @@ namespace Fungus
                 for (int i = 0; i < activeStages.Count; i++)
                 {
                     var stage = activeStages[i];
-                    //Make sure portraitImage.color is white
-                    if(!speakingCharacter.State.dimmed)
-                    {
-                        float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
-                        LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
-                    }
                     
                     if (stage.DimPortraits)
                     {
+                        //Make sure portraitImage.color is white
+                        if(!speakingCharacter.State.dimmed)
+                        {
+                            float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
+                            LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                        }
                         var charactersOnStage = stage.CharactersOnStage;
                         for (int j = 0; j < charactersOnStage.Count; j++)
                         {

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -351,16 +351,7 @@ namespace Fungus
                     var stage = activeStages[i];
                     
                     if (stage.DimPortraits)
-                    {
-                        //Make sure portraitImage.color is white
-                        if(speakingCharacter.State.portraitImage != null)
-                        {
-                            if(!speakingCharacter.State.dimmed)
-                            {
-                                float duration = (stage.FadeDuration > 0f) ? stage.FadeDuration : float.Epsilon;
-                                LeanTween.color(speakingCharacter.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
-                            }
-                        }
+                    {                        
                         var charactersOnStage = stage.CharactersOnStage;
                         for (int j = 0; j < charactersOnStage.Count; j++)
                         {
@@ -374,6 +365,22 @@ namespace Fungus
                                 else
                                 {
                                     stage.SetDimmed(c, false);
+                                }
+                            }
+
+                            //Dim issue workaround. Temporary solution until it completely fixed
+                            if(c != null && c.State.dimmed == false && c.State.portraitImage.color != Color.white)
+                            {
+                                if(c == speakingCharacter)
+                                {
+                                    LeanTween.color(c.State.portraitImage.rectTransform, Color.white, duration).setEase(stage.FadeEaseType).setRecursive(false);
+                                }
+                            }
+                            if(c != null && c.State.dimmed == true && c.State.portraitImage.color != stage.DimColor)
+                            {
+                                if(c == prevSpeakingCharacter)
+                                {
+                                    LeanTween.color(c.State.portraitImage.rectTransform, stage.DimColor, duration).setEase(stage.FadeEaseType).setRecursive(false);
                                 }
                             }
                         }


### PR DESCRIPTION
There was no conditional check before on whether the color of portraitImage is completely white or not when setting portraits to dimmedState. This fix issues which affect a lot of users on discord & forum.

~~Hope this can get to 3.14 release~~ as the dim issue pretty much breaks Fungus functionality and cause problems for those making visual novel game

EDIT: After further investigating the issue, this is not a proper fix! More of a workaround and do not merge this! Perhaps, somebody with a better knowledge on how Fungus' portrait system works would pick this up.

### Description
This pr partially fixes https://github.com/snozbot/fungus/issues/922

### What is the current behavior?
Dim portraits would sometimes set both speaking/not-speaking characters stuck to a dimmed state

### What is the new behavior?
As shown in videos below  
  
**BEFORE**  

https://user-images.githubusercontent.com/64100867/105013026-652a3000-5a71-11eb-884f-e7e43ebe657a.mp4  

**AFTER**  

https://user-images.githubusercontent.com/64100867/105013187-8f7bed80-5a71-11eb-92a3-c4169e354ab1.mp4

Edit: Description fix