### PR TITLE
Fix Writer Paused

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,18 +8,18 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is. Is it a bug during playback or a bug in editing Flowcharts, Blocks, Commands, and so on? When and where it is happening, is it only in editor or only in build or both?
+<!--A clear and concise description of what the bug is. Is it a bug during playback or a bug in editing Flowcharts, Blocks, Commands, and so on? When and where it is happening, is it only in editor or only in build or both?-->
 
 **To Reproduce**
-In order for someone else to attempt to solve the issue we need to know how to make it occur. As such when reporting bugs please detail how to make them occur in existing FungusExample scenes, or how to create a scene from empty, or attach a unitypackage with a minimal scene in it. 
-Then describe the steps to reproduce the behavior:
+<!--In order for someone else to attempt to solve the issue we need to know how to make it occur. As such when reporting bugs please detail how to make them occur in existing FungusExample scenes, or how to create a scene from empty, or attach a unitypackage with a minimal scene in it. 
+Then describe the steps to reproduce the behavior:-->
 1. Go to the scene '...' in the FungusExample ***OR*** In  a new scene, add the following '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error/undesired behaviour
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!--A clear and concise description of what you expected to happen.-->
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,16 @@ assignees: ''
 
 ---
 
-Please double check the feature or suggestion you have has not already been raised by searching within the existing [issues](https://github.com/snozbot/fungus/issues). If you find something similar to what you were thinking, please reply to the existing issue with either additional details/suggestions or simply a +1.
+<!--Please double check the feature or suggestion you have has not already been raised by searching within the existing [issues](https://github.com/snozbot/fungus/issues). If you find something similar to what you were thinking, please reply to the existing issue with either additional details/suggestions or simply a +1.-->
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--A clear and concise description of what you want to happen.-->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!--A clear and concise description of any alternative solutions or features you've considered.-->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!--Add any other context or screenshots about the feature request here.-->

--- a/Assets/Fungus/Scripts/Components/Writer.cs
+++ b/Assets/Fungus/Scripts/Components/Writer.cs
@@ -629,6 +629,7 @@ namespace Fungus
                     // No delay if user has clicked and Instant Complete is enabled
                     if (instantComplete && inputFlag)
                     {
+                        yield return null;
                         continue;
                     }
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Installation
 
 Download & installation instructions and tutorial videos are available in [the wiki](https://github.com/snozbot/fungus/wiki/installation) and the official [Fungus website](https://fungusgames.com).
 
-Support
+Support & Documentation
 =======
+
+The Fungus documentation is available on [our wiki](https://github.com/snozbot/fungus/wiki). Contributions to the wiki are very  welcome.
 
 If you have questions about Fungus, please search our forum first as someone may have had the same issue already. If you can't find an answer please start a new discussion and we'll answer you as soon as we can. Fungus is designed for beginners and we love to hear from users so please don't be shy about posting on [the forum](https://fungusgames.com/forum)!
 
@@ -23,6 +25,14 @@ There is also a community run [Discord server](https://discord.gg/99RqraQ).
 
 You can also join into our chat room.
 [![Join the chat at https://gitter.im/snozbot/fungus](https://badges.gitter.im/snozbot/fungus.svg)](https://gitter.im/snozbot/fungus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+
+Status & Branches
+=================
+
+Fungus uses a [gitflow](https://nvie.com/posts/a-successful-git-branching-model/) style setup. The default branch holds the most recent stable release. Develop is the staging ground for ongoing work and the default target of most PRs. 
+
+Develop is currently the staging ground for the next Fungus [feature release 3.14](https://github.com/snozbot/fungus/milestone/1)
 
 Contributing
 ============
@@ -32,11 +42,6 @@ Many thanks to everyone who has [contributed](https://github.com/snozbot/fungus/
 To contribute code or documentation to Fungus, please see [CONTRIBUTING](https://github.com/snozbot/fungus/blob/master/CONTRIBUTING.md).
 
 You can view the upcoming roadmap via the [Milestones](https://github.com/snozbot/fungus/milestones).
-
-Documentation
-==========================
-
-The Fungus documentation is available on [our wiki](https://github.com/snozbot/fungus/wiki). Contributions to the wiki are very  welcome.
 
 Running the automated tests
 ===========================


### PR DESCRIPTION
This prevent single button press counts as multiple presses at once, as previously would, thus makes sentence gets instantly completed.

This pr fixes https://github.com/snozbot/fungus/issues/936

### What is the current behavior?
**BEFORE**  

https://user-images.githubusercontent.com/64100867/105035969-64ec5d80-5a8e-11eb-9c87-9746d47bf093.mp4


### What is the new behavior?
**AFTER**


https://user-images.githubusercontent.com/64100867/105035994-7170b600-5a8e-11eb-9da3-2f3ca404d9b0.mp4


### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change does not require modifcations or additions to documentation
