### PR TITLE
Add 3rd Person Dim

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,18 +8,18 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is. Is it a bug during playback or a bug in editing Flowcharts, Blocks, Commands, and so on? When and where it is happening, is it only in editor or only in build or both?
+<!--A clear and concise description of what the bug is. Is it a bug during playback or a bug in editing Flowcharts, Blocks, Commands, and so on? When and where it is happening, is it only in editor or only in build or both?-->
 
 **To Reproduce**
-In order for someone else to attempt to solve the issue we need to know how to make it occur. As such when reporting bugs please detail how to make them occur in existing FungusExample scenes, or how to create a scene from empty, or attach a unitypackage with a minimal scene in it. 
-Then describe the steps to reproduce the behavior:
+<!--In order for someone else to attempt to solve the issue we need to know how to make it occur. As such when reporting bugs please detail how to make them occur in existing FungusExample scenes, or how to create a scene from empty, or attach a unitypackage with a minimal scene in it. 
+Then describe the steps to reproduce the behavior:-->
 1. Go to the scene '...' in the FungusExample ***OR*** In  a new scene, add the following '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error/undesired behaviour
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!--A clear and concise description of what you expected to happen.-->
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,16 @@ assignees: ''
 
 ---
 
-Please double check the feature or suggestion you have has not already been raised by searching within the existing [issues](https://github.com/snozbot/fungus/issues). If you find something similar to what you were thinking, please reply to the existing issue with either additional details/suggestions or simply a +1.
+<!--Please double check the feature or suggestion you have has not already been raised by searching within the existing [issues](https://github.com/snozbot/fungus/issues). If you find something similar to what you were thinking, please reply to the existing issue with either additional details/suggestions or simply a +1.-->
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--A clear and concise description of what you want to happen.-->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!--A clear and concise description of any alternative solutions or features you've considered.-->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!--Add any other context or screenshots about the feature request here.-->

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -366,6 +366,13 @@ namespace Fungus
                                     stage.SetDimmed(c, false);
                                 }
                             }
+                            if(stage.thirdPersonDim)
+                            {
+                                if(speakingCharacter.State.portraitImage == null)
+                                {
+                                    stage.SetDimmed(c, false);
+                                }
+                            }
                         }
                     }
                 }

--- a/Assets/Fungus/Scripts/Components/Stage.cs
+++ b/Assets/Fungus/Scripts/Components/Stage.cs
@@ -19,7 +19,8 @@ namespace Fungus
 
         [Tooltip("Dim portraits when a character is not speaking.")]
         [SerializeField] protected bool dimPortraits;
-
+        [Tooltip("Un-Dim portraits when a there's a speaking character with no portrait on screen")]
+        [SerializeField] protected bool thirdPersonDim;
         [Tooltip("Choose a dimColor")]
         [SerializeField] protected Color dimColor =new Color(0.5f, 0.5f, 0.5f, 1f);
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Installation
 
 Download & installation instructions and tutorial videos are available in [the wiki](https://github.com/snozbot/fungus/wiki/installation) and the official [Fungus website](https://fungusgames.com).
 
-Support
+Support & Documentation
 =======
+
+The Fungus documentation is available on [our wiki](https://github.com/snozbot/fungus/wiki). Contributions to the wiki are very  welcome.
 
 If you have questions about Fungus, please search our forum first as someone may have had the same issue already. If you can't find an answer please start a new discussion and we'll answer you as soon as we can. Fungus is designed for beginners and we love to hear from users so please don't be shy about posting on [the forum](https://fungusgames.com/forum)!
 
@@ -23,6 +25,14 @@ There is also a community run [Discord server](https://discord.gg/99RqraQ).
 
 You can also join into our chat room.
 [![Join the chat at https://gitter.im/snozbot/fungus](https://badges.gitter.im/snozbot/fungus.svg)](https://gitter.im/snozbot/fungus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+
+Status & Branches
+=================
+
+Fungus uses a [gitflow](https://nvie.com/posts/a-successful-git-branching-model/) style setup. The default branch holds the most recent stable release. Develop is the staging ground for ongoing work and the default target of most PRs. 
+
+Develop is currently the staging ground for the next Fungus [feature release 3.14](https://github.com/snozbot/fungus/milestone/1)
 
 Contributing
 ============
@@ -32,11 +42,6 @@ Many thanks to everyone who has [contributed](https://github.com/snozbot/fungus/
 To contribute code or documentation to Fungus, please see [CONTRIBUTING](https://github.com/snozbot/fungus/blob/master/CONTRIBUTING.md).
 
 You can view the upcoming roadmap via the [Milestones](https://github.com/snozbot/fungus/milestones).
-
-Documentation
-==========================
-
-The Fungus documentation is available on [our wiki](https://github.com/snozbot/fungus/wiki). Contributions to the wiki are very  welcome.
 
 Running the automated tests
 ===========================


### PR DESCRIPTION
### Description
Currently, when there's a 3rd person speaking all active characters on stage will be dimmed. This pr add an option for when 3rd speaker/narrator (without portrait shown on Stage) will keep active characters on Screen undimmed.

### What is the current behavior?
When 3rd person/narrator with no portrait shown on screen, all active characters will be dimmed.

### What is the new behavior?
All active characters shown on screen will not be dimmed if 3rd person/narrator without a portrait is speaking.

### Important Notes
- My change require modifcations or additions to documentation
