### PR TITLE
Fixed destriying of EventHandler on "Create/Fowchart" menu item

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FlowchartMenuItems.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartMenuItems.cs
@@ -25,8 +25,11 @@ namespace Fungus.EditorUtils
             if (GameObject.FindObjectsOfType<Flowchart>().Length > 1)
             {
                 var block = go.GetComponent<Block>();
-                GameObject.DestroyImmediate(block._EventHandler);
-                block._EventHandler = null;
+                if (block._EventHandler is GameStarted)
+                {
+                    GameObject.DestroyImmediate(block._EventHandler);
+                    block._EventHandler = null;
+                }
             }
         }
 


### PR DESCRIPTION
Comment in code says that this should apply only to GameStarted event handler.
Now prefab may have a default EventHandler that is not a GameStarted. For example, MessageReceived.

### What is the current behavior?
I change the Flowchart prefab to have MessageReceived as a default event handler.
When creating Flowchart using "Tools/Fungus/Create/Flowchart" menu item, EventHandler gets deleted.

### What is the new behavior?
I change the Flowchart prefab to have MessageReceived as a default event handler.
When creating Flowchart using "Tools/Fungus/Create/Flowchart" menu item, EventHandler stays as expected.

Ohh... And I see I added a new line character at the end of the file. I don't know how to fix this:)
