### PR TITLE
Fix GetSecondsRemaining

### DIFF
--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -106,7 +106,7 @@ namespace Fungus
         {
             if (playingVoiceover)
             {
-                return lastUsedAudioSource.clip.length - lastUsedAudioSource.time;
+                return targetAudioSource.isPlaying ? targetAudioSource.clip.length - targetAudioSource.time : 0f;
             }
             else
             {


### PR DESCRIPTION
### Description
While doing lipsync, I ran into the fact that it is impossible to understand when the voice over clip finishes its playback.

### What is the current behavior?
After playing a voice, the GetSecondsRemaining returns its full duration audio clip.

### What is the new behavior?
After the voice clip has finished playing, the number of seconds remaining becomes 0.