### PR TITLE
Retain Command.ItemId on Cut and Paste

### DIFF
--- a/Assets/Fungus/Scripts/Components/CommandCopyBuffer.cs
+++ b/Assets/Fungus/Scripts/Components/CommandCopyBuffer.cs
@@ -70,6 +70,8 @@ namespace Fungus
             }
         }
 
+        public bool IsCut { get; set; }
+
         #endregion
     }
 }


### PR DESCRIPTION
### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Do not assign new ItemId to pasted commands on Cut and Paste. This is causing issue for me as I use ItemId to manage saves in my project.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
Paste always assign a new ItemId to pasted commands.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Pasted commands will retain ItemId
- Cut and Paste will clear CopyCommandBuffer