### PR TITLE
Fix double duplication of blocks with Ctrl+D

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -1897,11 +1897,8 @@ namespace Fungus.EditorUtils
         {
             copyList.Clear();
 
-            foreach (var block in flowchart.SelectedBlocks)
-            {
-                copyList.Add(new BlockCopy(block));
-            }
-            foreach (var block in mouseDownSelectionState)
+            foreach (var block in flowchart.SelectedBlocks
+                .Union(mouseDownSelectionState))
             {
                 copyList.Add(new BlockCopy(block));
             }


### PR DESCRIPTION
### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Fix bug where Ctrl+D will duplicate selected blocks twice.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
1. Select blocks
2. Press Ctrl+D to duplicate
3. Every selected blocks will be duplicated twice (one of them hidden behind the other)

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Union blocks before copying