### PR TITLE
Fix visual bug when dragging blocks with FungusEditorPreferences.useGridSnap enabled

### DIFF
--- a/Assets/Fungus/Scripts/Editor/EditorZoomArea.cs
+++ b/Assets/Fungus/Scripts/Editor/EditorZoomArea.cs
@@ -56,9 +56,8 @@ namespace Fungus.EditorUtils
         public static Rect SnapPosition(this Rect rect, float snapInterval)
         {
             var tmp = rect;
-            var x = tmp.position.x;
-            var y = tmp.position.y;
-            tmp.position = new Vector2(Mathf.RoundToInt(x / snapInterval) * snapInterval, Mathf.RoundToInt(y / snapInterval) * snapInterval);
+            var pos = tmp.position;
+            tmp.position = new Vector2(Mathf.RoundToInt(pos.x / snapInterval) * snapInterval, Mathf.RoundToInt(pos.y / snapInterval) * snapInterval);
             return tmp;
         }
 

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -1709,13 +1709,13 @@ namespace Fungus.EditorUtils
         {
             //previous method made a lot of garbage so now we reuse the same array
             pointsA[0] = new Vector2(rectA.xMin, rectA.center.y);
-            pointsA[1] = new Vector2(rectA.xMin + rectA.width / 2, rectA.yMin);
-            pointsA[2] = new Vector2(rectA.xMin + rectA.width / 2, rectA.yMax);
+            pointsA[1] = new Vector2(rectA.xMin + rectA.width * .5f, rectA.yMin);
+            pointsA[2] = new Vector2(rectA.xMin + rectA.width * .5f, rectA.yMax);
             pointsA[3] = new Vector2(rectA.xMax, rectA.center.y);
 
             pointsB[0] = new Vector2(rectB.xMin, rectB.center.y);
-            pointsB[1] = new Vector2(rectB.xMin + rectB.width / 2, rectB.yMin);
-            pointsB[2] = new Vector2(rectB.xMin + rectB.width / 2, rectB.yMax);
+            pointsB[1] = new Vector2(rectB.xMin + rectB.width * .5f, rectB.yMin);
+            pointsB[2] = new Vector2(rectB.xMin + rectB.width * .5f, rectB.yMax);
             pointsB[3] = new Vector2(rectB.xMax, rectB.center.y);
 
             Vector2 pointA = Vector2.zero;

--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -1174,12 +1174,12 @@ namespace Fungus.EditorUtils
                 // Block dragging
                 if (dragBlock != null)
                 {
+                    var distance = e.mousePosition / flowchart.Zoom - flowchart.ScrollPos - startDragPosition;
                     for (int i = 0; i < flowchart.SelectedBlocks.Count; ++i)
                     {
                         var block = flowchart.SelectedBlocks[i];
                         var tempRect = tempRectDict[block];
-                        tempRect.position += e.delta / flowchart.Zoom;
-                        tempRectDict[block] = tempRect;
+                        tempRect.position += distance;
                         block._NodeRect = FungusEditorPreferences.useGridSnap ? tempRect.SnapPosition(GridObjectSnap) : tempRect;
                     }
 
@@ -1276,12 +1276,13 @@ namespace Fungus.EditorUtils
 
                 if (dragBlock != null)
                 {
+                    var distance = e.mousePosition / flowchart.Zoom - flowchart.ScrollPos - startDragPosition;
                     for (int i = 0; i < flowchart.SelectedBlocks.Count; ++i)
                     {
                         var block = flowchart.SelectedBlocks[i];
                         var nodeRect = block._NodeRect;
                         var tempRect = nodeRect;
-                        tempRect.position -= e.mousePosition / flowchart.Zoom - flowchart.ScrollPos - startDragPosition;
+                        tempRect.position -= distance;
                         block._NodeRect = FungusEditorPreferences.useGridSnap ? tempRect.SnapPosition(GridObjectSnap) : tempRect;
                         Undo.RecordObject(block, "Block Position");
                         block._NodeRect = nodeRect;


### PR DESCRIPTION
### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Minor refactoring to fix visual bug when FungusEditorPreferences.useGridSnap is enabled.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
When FungusEditorPreferences.useGridSnap is enabled, labels and connections do not follow the snapped position of block._NodeRect. Apparently, this change also fixes the snap width when scrolling.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Store and use temp block rect values
- Manage in OnMouse methods instead of Draw methods