### PR TITLE
Add ForceMeshUpdate to TextAdapter

### DIFF
--- a/Assets/Fungus/Docs/CHANGELOG.txt
+++ b/Assets/Fungus/Docs/CHANGELOG.txt
@@ -20,6 +20,7 @@ Unreleased
 ## Fixed
  - Many Summaries that had \\ instead of \\\
  - Add missing VariableDrawer for ObjectVariable. Thanks to CG-Tespy.
+ - TextAdapter with TMPro, now forces mesh update on text change. Fixes cases where a Say/Writer would expect RevealedCharacters to be current but would be previous frame stale value.  
  
 ## Changed
  - SetSliderValue command can now also get the current value of the target slider.

--- a/Assets/Fungus/Scripts/Utils/TextAdapter.cs
+++ b/Assets/Fungus/Scripts/Utils/TextAdapter.cs
@@ -320,6 +320,7 @@ namespace Fungus
                 else if (tmpro != null)
                 {
                     tmpro.text = value;
+                    tmpro.ForceMeshUpdate();
                 }
 #endif
                 else if (textProperty != null)


### PR DESCRIPTION
Ensures subsequent calls to tmpro related elements, such as revealed characters, are not stale.

Relates to #910 and #954 
