### PR TITLE
Update deprecated isNetworkError

### DIFF
--- a/Assets/Fungus/Thirdparty/FungusLua/Thirdparty/JSON/Editor/JSONChecker.cs
+++ b/Assets/Fungus/Thirdparty/FungusLua/Thirdparty/JSON/Editor/JSONChecker.cs
@@ -73,7 +73,7 @@ public class JSONChecker : EditorWindow {
 #if UNITY_2017_1_OR_NEWER
 			var test = new UnityWebRequest(URL);
 			test.SendWebRequest();
-			while (!test.isDone && !test.isNetworkError) ;
+			while (!test.isDone && test.result == UnityWebRequest.Result.ConnectionError);
 #else
 			var test = new WWW(URL);
  			while (!test.isDone) ;


### PR DESCRIPTION
### Description
replace deprecated isNetworkError with UnityWebRequest.Result.ConnectionError

### Other information

closes https://github.com/snozbot/fungus/issues/961