### PR TITLE
Fix StackOverflow Exception When Skipping While Flash Still Active

### DIFF
--- a/Assets/Fungus/Scripts/Components/CameraManager.cs
+++ b/Assets/Fungus/Scripts/Components/CameraManager.cs
@@ -301,7 +301,7 @@ namespace Fungus
 
         protected void StopFadeTween()
         {
-            if (fadeTween != null)
+            if (fadeTween != null && !LeanTween.isTweening(fadeTween.id))
             {
                 LeanTween.cancel(fadeTween.id, true);
                 fadeTween = null;


### PR DESCRIPTION
### Description
When skipping dialogue while Flash still not done tweening, it will cause StackOverflow Exception

### What is the current behavior?
Skipping dialogue will throw StackOverflow Exception while flash is not done tweening

### What is the new behavior?
Will not re-instantiate tween if Flash is still active 

### Other information

Closes https://github.com/snozbot/fungus/issues/973