### PR TITLE
Limit Characters Shown In NarrativeLog to Avoid 65000 Vertices Limit

### DIFF
--- a/Assets/Fungus/Scripts/Components/NarrativeLog.cs
+++ b/Assets/Fungus/Scripts/Components/NarrativeLog.cs
@@ -35,6 +35,7 @@ namespace Fungus
         /// </summary>
         public static event NarrativeAddedHandler OnNarrativeAdded;
         public delegate void NarrativeAddedHandler(NarrativeLogEntry data);
+        public static int maxSize {get; set;} = 10000;
         public static void DoNarrativeAdded(NarrativeLogEntry data)
         {
             if (OnNarrativeAdded != null)
@@ -140,6 +141,12 @@ namespace Fungus
                 output += "<b>" + history.entries[i].name + "</b>\n";
                 output += history.entries[i].text + "\n\n";
             }
+
+            if (output.Length > maxSize)
+            {
+                output =  "... " + output.Substring(output.Length - maxSize, maxSize);
+            }
+
             return output;
         }
 

--- a/Assets/Fungus/Scripts/Components/NarrativeLogMenu.cs
+++ b/Assets/Fungus/Scripts/Components/NarrativeLogMenu.cs
@@ -26,6 +26,9 @@ namespace Fungus
         [Tooltip("A scrollable text field used for displaying conversation history.")]
         [SerializeField] protected ScrollRect narrativeLogView;
 
+        [Tooltip("Limit characters to be shown in Narrative Log")]
+        [SerializeField] protected int maxCharacters = 10000;
+
         protected TextAdapter narLogViewtextAdapter = new TextAdapter();
         
         [Tooltip("The CanvasGroup containing the save menu buttons")]
@@ -132,6 +135,7 @@ namespace Fungus
         {
             if (narrativeLogView.enabled)
             {
+                NarrativeLog.maxSize = maxCharacters;
                 narLogViewtextAdapter.Text = FungusManager.Instance.NarrativeLog.GetPrettyHistory();
                 
                 Canvas.ForceUpdateCanvases();


### PR DESCRIPTION
### Description
Fixes 65000 vertices limit by limiting character shown in NarrativeLog

### What is the current behavior?
It will throw **ArgumentException: Mesh can not have more than 65000 vertices** if NarrativeLog texts over 65000 vertices

### What is the new behavior?
The text will get truncated to default 10000 characters (users can change the characters limit) and a tripple-dots prefix will be added as indicator that it was truncated

**BEFORE**  

https://user-images.githubusercontent.com/64100867/121877827-3faa0580-cd35-11eb-8fba-3f2e83578e8c.mp4


**AFTER**  

https://user-images.githubusercontent.com/64100867/121878023-708a3a80-cd35-11eb-9a30-881bf98f9f23.mp4



### Other information

Edit: Description edit

Relates to https://github.com/snozbot/fungus/issues/945
