### PR TITLE
QoL Update: Select and scroll to new command on add

### DIFF
--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -45,6 +45,9 @@ namespace Fungus
         [Tooltip("Sound effect to play on user input (e.g. a click)")]
         [SerializeField] protected AudioClip inputSound;
 
+        [Tooltip("Lerp voice effect while playing. Enabled results in smoother volume transitions between different write sounds. Disable to keep writer volume constant.")]
+        [SerializeField] protected bool lerpWriterVolume = true;
+
         protected float targetVolume = 0f;
 
         // When true, a beep will be played on every written character glyph
@@ -219,8 +222,17 @@ namespace Fungus
 
         protected virtual void Update()
         {
-            if(lastUsedAudioSource != null)
-                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+            if (lastUsedAudioSource != null)
+            {
+                if (lerpWriterVolume)
+                {
+                    lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+                }
+                else
+                {
+                    lastUsedAudioSource.volume = targetVolume;
+                }
+            }
         }
 
         #region IWriterListener implementation

--- a/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
@@ -11,6 +11,12 @@ namespace Fungus.EditorUtils
 {
     public class CommandListAdaptor
     {
+        /// <summary>
+        /// If true, scrolls to the currently selected command in the inspector when the editor is redrawn. A
+        /// Automatically resets to false.
+        /// </summary>
+        public static bool ScrollToCommandOnDraw = false;
+
         public void DrawCommandList()
         {
             if (summaryStyle == null)
@@ -173,6 +179,11 @@ namespace Fungus.EditorUtils
                 if (selectedCommand == command)
                 {
                     commandIsSelected = true;
+                    if (ScrollToCommandOnDraw)
+                    {
+                        GUI.ScrollTo(position);
+                        ScrollToCommandOnDraw = false;
+                    }
                     break;
                 }
             }

--- a/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
@@ -181,7 +181,11 @@ namespace Fungus.EditorUtils
             // Because this is an async call, we need to force prefab instances to record changes
             PrefabUtility.RecordPrefabInstancePropertyModifications(block);
 
-            flowchart.ClearSelectedCommands();
+            //clear commands just in case there was a selection made prior, 
+            // this way, only one command is selected at the end; the new one.
+            flowchart.ClearSelectedCommands(); 
+            
+            flowchart.SelectedCommands.Add(newCommand); //select the new command.
 
         }
     }

--- a/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
+++ b/Assets/Fungus/Scripts/Editor/PopupContent/CommandSelectorPopupWindowContent.cs
@@ -183,10 +183,10 @@ namespace Fungus.EditorUtils
 
             //clear commands just in case there was a selection made prior, 
             // this way, only one command is selected at the end; the new one.
-            flowchart.ClearSelectedCommands(); 
-            
-            flowchart.SelectedCommands.Add(newCommand); //select the new command.
+            flowchart.ClearSelectedCommands();
 
+            CommandListAdaptor.ScrollToCommandOnDraw = true;
+            flowchart.AddSelectedCommand(newCommand); //select the new command.
         }
     }
 }

--- a/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
@@ -17,6 +17,7 @@ namespace Fungus.EditorUtils
         protected SerializedProperty soundEffectProp;
         protected SerializedProperty inputSoundProp;
         protected SerializedProperty useLegacyAudioLogicProp;
+        protected SerializedProperty lerpAudioProp;
 
         protected virtual void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace Fungus.EditorUtils
             beepSoundsProp = serializedObject.FindProperty("beepSounds");
             soundEffectProp = serializedObject.FindProperty("soundEffect");
             useLegacyAudioLogicProp = serializedObject.FindProperty("useLegacyAudioLogic");
+            lerpAudioProp = serializedObject.FindProperty("lerpWriterVolume");
         }
 
         public override void OnInspectorGUI() 
@@ -37,6 +39,7 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(volumeProp);
             EditorGUILayout.PropertyField(loopProp);
             EditorGUILayout.PropertyField(useLegacyAudioLogicProp);
+            EditorGUILayout.PropertyField(lerpAudioProp);
             if (useLegacyAudioLogicProp.boolValue)
             {
                 EditorGUILayout.PropertyField(targetAudioSourceProp);


### PR DESCRIPTION
### Description
Minor quality of life update. When a new command is added from the command list, it will automatically select that new command and also scroll to it in the inspector if needed. Subsequently added commands will also go underneath the new command instead of going straight to the bottom.

Note: This does not affect copy + paste or duplicate. That can be addressed in a different PR since that's kind of niche. This only affects adding new commands from the commands menu.

Additionally, this is untested with the old menu layout. It *should* work though. If not, I'll add a toggle so this feature is disabled when using the old ui.

### What is the current behavior?
Currently, when a new command is added, it goes to whatever the currently selected command is, which isn't bad, but it deselects commands, requiring you to click on the new command in order to modify it.

Additionally, if adding commands in sequence (repeatedly adding them), any additional commands will go to the bottom of the list. This isn't bad unless you're trying to set up stuff in the middle of an already configured block. 

Resolves #994 

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- The adding of commands is streamlined so when you add a command, it's already selected for editing and adding new commands under it.

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.
     - Only partially. Those who are used to clicking new commands will be affected.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
**Important:** because I did a silly, this PR includes changes from PR #934 which contains an optional boolean to Writer Audio. When merging this branch, 934 can be deleted as this already contains it. (as usual)
