### PR TITLE
New Feature: Lockable flowchart

### DIFF
--- a/Assets/Fungus/Scripts/Components/Flowchart.cs
+++ b/Assets/Fungus/Scripts/Components/Flowchart.cs
@@ -24,6 +24,9 @@ namespace Fungus
         [SerializeField] protected int version = 0; // Default to 0 to always trigger an update for older versions of Fungus.
 
         [HideInInspector]
+        [SerializeField] public bool locked = false;
+
+        [HideInInspector]
         [SerializeField] protected Vector2 scrollPos;
 
         [HideInInspector]

--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -45,6 +45,9 @@ namespace Fungus
         [Tooltip("Sound effect to play on user input (e.g. a click)")]
         [SerializeField] protected AudioClip inputSound;
 
+        [Tooltip("Lerp voice effect while playing. Enabled results in smoother volume transitions between different write sounds. Disable to keep writer volume constant.")]
+        [SerializeField] protected bool lerpWriterVolume = true;
+
         protected float targetVolume = 0f;
 
         // When true, a beep will be played on every written character glyph
@@ -219,8 +222,17 @@ namespace Fungus
 
         protected virtual void Update()
         {
-            if(lastUsedAudioSource != null)
-                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+            if (lastUsedAudioSource != null)
+            {
+                if (lerpWriterVolume)
+                {
+                    lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+                }
+                else
+                {
+                    lastUsedAudioSource.volume = targetVolume;
+                }
+            }
         }
 
         #region IWriterListener implementation

--- a/Assets/Fungus/Scripts/Editor/BlockEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockEditor.cs
@@ -163,7 +163,7 @@ namespace Fungus.EditorUtils
                     CacheCallerString();
                     GUI.enabled = false;
                     EditorGUILayout.TextArea(callersString);
-                    GUI.enabled = true;
+                    GUI.enabled = true; //reset
                 }
                 EditorGUI.indentLevel--;
                 
@@ -186,7 +186,13 @@ namespace Fungus.EditorUtils
 
                 EditorGUILayout.Space();
 
+                GUI.enabled = true; //reset
+
+                //skip GUI enabled here; command list has its own method to handle locking. 
+                //This way, commands can still be selected and read
                 commandListAdaptor.DrawCommandList();
+
+                GUI.enabled = !flowchart.locked; //toggle again to disable context menu
 
                 // EventType.contextClick doesn't register since we moved the Block Editor to be inside
                 // a GUI Area, no idea why. As a workaround we just check for right click instead.
@@ -292,6 +298,8 @@ namespace Fungus.EditorUtils
                 }
             }
 
+            GUI.enabled = true; //reset
+
             // Remove any null entries in the command list.
             // This can happen when a command class is deleted or renamed.
             for (int i = commandListProperty.arraySize - 1; i >= 0; --i)
@@ -358,6 +366,8 @@ namespace Fungus.EditorUtils
                 lastCMDpopupPos.x += EditorGUIUtility.labelWidth;
                 lastCMDpopupPos.y += EditorGUIUtility.singleLineHeight * 2;
             }
+
+            GUI.enabled = !CommandListAdaptor.lockCommandList; //flowchart reference does not exist here, use this to check if it's locked
             // Add Button
             if (GUILayout.Button(addIcon))
             {
@@ -384,6 +394,8 @@ namespace Fungus.EditorUtils
             {
                 Delete();
             }
+
+            GUI.enabled = true; //reset
 
             GUILayout.EndHorizontal();
 

--- a/Assets/Fungus/Scripts/Editor/BlockInspector.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockInspector.cs
@@ -93,6 +93,8 @@ namespace Fungus.EditorUtils
                 return;
             }
 
+            GUI.enabled = !flowchart.locked; //lock the block header
+
             //if there is no selection but we are drawing, fix that
             if (flowchart.SelectedBlocks.Count == 0)
             {
@@ -161,12 +163,12 @@ namespace Fungus.EditorUtils
 
             if (inspectCommand != null)
             {
+                GUI.enabled = !flowchart.locked; //disable command editor if locked
                 if (activeCommandEditor == null || 
                     !inspectCommand.Equals(activeCommandEditor.target))
                 {
                     // See if we have a cached version of the command editor already,
                     var editors = (from e in cachedCommandEditors where (e != null && (e.target.Equals(inspectCommand))) select e);
-
                     if (editors.Count() > 0)
                     {
                         // Use cached editor
@@ -183,6 +185,7 @@ namespace Fungus.EditorUtils
                 {
                     activeCommandEditor.DrawCommandInspectorGUI();
                 }
+                GUI.enabled = true; //reset
             }
 
             GUILayout.EndScrollView();

--- a/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/CommandListAdaptor.cs
@@ -11,8 +11,13 @@ namespace Fungus.EditorUtils
 {
     public class CommandListAdaptor
     {
+
+        public static bool lockCommandList = false;
+
         public void DrawCommandList()
         {
+            list.draggable = !lockCommandList;
+
             if (summaryStyle == null)
             {
                 summaryStyle = new GUIStyle();
@@ -84,7 +89,7 @@ namespace Fungus.EditorUtils
             this._arrayProperty = arrayProperty;
             this.block = _block;
 
-            list = new ReorderableList(arrayProperty.serializedObject, arrayProperty, true, true, false, false);
+            list = new ReorderableList(arrayProperty.serializedObject, arrayProperty, !lockCommandList, true, false, false);
             list.drawHeaderCallback = DrawHeader;
             list.drawElementCallback = DrawItem;
             //list.elementHeightCallback = GetElementHeight;

--- a/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartEditor.cs
@@ -90,7 +90,34 @@ namespace Fungus.EditorUtils
             {
                 EditorWindow.GetWindow(typeof(FlowchartWindow), false, "Flowchart");
             }
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
 
+            GUILayout.Space(10);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (flowchart.locked)
+            {
+                if (GUILayout.Button(new GUIContent("Unlock Flowchart", "Unlocks the flowchart, allowing it to be edited.")))
+                {
+                    flowchart.locked = false;
+                    Undo.RecordObject(flowchart, "Unlock Flowchart " + flowchart.name);
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(flowchart);
+                }
+            }
+            else
+            {
+                if (GUILayout.Button(new GUIContent("Lock Flowchart", "Locks the flowchart, preventing it from being edited.")))
+                {
+                    flowchart.locked = true;
+                    Undo.RecordObject(flowchart, "Lock Flowchart " + flowchart.name);
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(flowchart);
+                }
+            }
+
+            CommandListAdaptor.lockCommandList = flowchart.locked; // pass to commandlist so it can repaint
+            EditorWindow.GetWindow(typeof(FlowchartWindow), false, "Flowchart").Repaint(); //force flowchart window to repaint
 
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();

--- a/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
+++ b/Assets/Fungus/Scripts/Editor/VariableListAdaptor.cs
@@ -146,7 +146,11 @@ namespace Fungus.EditorUtils
 
                 if (_arrayProperty.isExpanded)
                 {
+                    //disable variable list if locked. The list can still be expanded
+                    //applies to flowchart window and flowchart inspector
+                    GUI.enabled = !TargetFlowchart.locked;
                     list.DoLayoutList();
+                    GUI.enabled = true; //reset
                 }
                 _arrayProperty.serializedObject.ApplyModifiedProperties();
             }

--- a/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
@@ -17,6 +17,7 @@ namespace Fungus.EditorUtils
         protected SerializedProperty soundEffectProp;
         protected SerializedProperty inputSoundProp;
         protected SerializedProperty useLegacyAudioLogicProp;
+        protected SerializedProperty lerpAudioProp;
 
         protected virtual void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace Fungus.EditorUtils
             beepSoundsProp = serializedObject.FindProperty("beepSounds");
             soundEffectProp = serializedObject.FindProperty("soundEffect");
             useLegacyAudioLogicProp = serializedObject.FindProperty("useLegacyAudioLogic");
+            lerpAudioProp = serializedObject.FindProperty("lerpWriterVolume");
         }
 
         public override void OnInspectorGUI() 
@@ -37,6 +39,7 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(volumeProp);
             EditorGUILayout.PropertyField(loopProp);
             EditorGUILayout.PropertyField(useLegacyAudioLogicProp);
+            EditorGUILayout.PropertyField(lerpAudioProp);
             if (useLegacyAudioLogicProp.boolValue)
             {
                 EditorGUILayout.PropertyField(targetAudioSourceProp);


### PR DESCRIPTION
### Description
Added an update to the flowchart window and editors so flowcharts can be locked, preventing editing. 

### What is the current behavior?
Currently, when working with flowchart prefabs and defaults, you may want the flowchart to not be editable at least not without needing to. This can also be useful for tracking what flowcharts are done and not. 


Issue Number: #992 

### What is the new behavior?
Clicking on the padlock icon in the flowchart window (or "lock flowchart" in the flowchart inspector) will lock the flowchart. It will not keep the flowchart in the editor window, unlike locking an inspector, but will prevent the blocks, commands, metadata, and variables from being changed. However, you can still scroll through commands to view them and move through the flowchart freely. It does work by greying out the properties, however. Will edit later if needed.

![ezgif-3-5d24a5c22987](https://user-images.githubusercontent.com/31874317/122661350-fd2a6380-d14e-11eb-8c65-722e8901eae4.gif)

In the future, the flowchart window can be adjusted to also lock on one flowchart, not changing if another is selected. However this will only be useful when multiple flowchart windows can be opened at once; a feature that seems to be missing for now.

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.
     - Possibly. Flowcharts are unlocked by default so it shouldn't change much.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
So far, no breaking changes have been found and it should also merge with #996 with how I edited the code. One main issue is that users may see the padlock and think it locks the flowchart in that window when it does not; only locks editing of it. This will be addressed when multiple flowchart windows can be open, at which point an additional behaviour will be added.

### Other information

**Important:** because I did a silly, this PR includes changes from PR #934 which contains an optional boolean to Writer Audio. When merging this branch, 934 can be deleted as this already contains it. (as usual)
