### PR TITLE
Selection Box Get Stuck Fix

### DIFF
--- a/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
+++ b/Assets/Fungus/Scripts/Editor/FlowchartWindow.cs
@@ -806,7 +806,15 @@ namespace Fungus.EditorUtils
             {
                 if (startSelectionBoxPosition.x >= 0 && startSelectionBoxPosition.y >= 0)
                 {
+                    var flochartWindow = EditorGUIUtility.currentViewWidth;
+                    
                     GUI.Box(selectionBox, "", GUI.skin.FindStyle("SelectionRect"));
+
+                    if(Event.current.mousePosition.x >= flochartWindow)
+                    {
+                        selectionBox.size = -Vector2.zero;
+                        Repaint();
+                    }
                 }
             }
 


### PR DESCRIPTION
### Description
Fix the issue of when selection box get stuck when pointer leaving flowchart window in the middle of selecting blocks

### What is the current behavior?
Selection box will get stuck if mouse/pointer leaving flowchart window 

### What is the new behavior?
Will set the selectionBox.size to 0 then repaint it.

https://user-images.githubusercontent.com/64100867/123407240-f29c1e00-d5d5-11eb-80b6-3de8be111c8a.mp4

### Other information

Relates to https://github.com/snozbot/fungus/issues/1002
