### PR TITLE
Added Requested Feature: Writer Audio lerp toggle (take 3)

### DIFF
--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -45,6 +45,9 @@ namespace Fungus
         [Tooltip("Sound effect to play on user input (e.g. a click)")]
         [SerializeField] protected AudioClip inputSound;
 
+        [Tooltip("Lerp voice effect while playing. Enabled results in smoother volume transitions between different write sounds. Disable to keep writer volume constant.")]
+        [SerializeField] protected bool lerpWriterVolume = true;
+
         protected float targetVolume = 0f;
 
         // When true, a beep will be played on every written character glyph
@@ -219,8 +222,17 @@ namespace Fungus
 
         protected virtual void Update()
         {
-            if(lastUsedAudioSource != null)
-                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+            if (lastUsedAudioSource != null)
+            {
+                if (lerpWriterVolume)
+                {
+                    lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+                }
+                else
+                {
+                    lastUsedAudioSource.volume = targetVolume;
+                }
+            }
         }
 
         #region IWriterListener implementation

--- a/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/WriterAudioEditor.cs
@@ -17,6 +17,7 @@ namespace Fungus.EditorUtils
         protected SerializedProperty soundEffectProp;
         protected SerializedProperty inputSoundProp;
         protected SerializedProperty useLegacyAudioLogicProp;
+        protected SerializedProperty lerpAudioProp;
 
         protected virtual void OnEnable()
         {
@@ -28,6 +29,7 @@ namespace Fungus.EditorUtils
             beepSoundsProp = serializedObject.FindProperty("beepSounds");
             soundEffectProp = serializedObject.FindProperty("soundEffect");
             useLegacyAudioLogicProp = serializedObject.FindProperty("useLegacyAudioLogic");
+            lerpAudioProp = serializedObject.FindProperty("lerpWriterVolume");
         }
 
         public override void OnInspectorGUI() 
@@ -37,6 +39,7 @@ namespace Fungus.EditorUtils
             EditorGUILayout.PropertyField(volumeProp);
             EditorGUILayout.PropertyField(loopProp);
             EditorGUILayout.PropertyField(useLegacyAudioLogicProp);
+            EditorGUILayout.PropertyField(lerpAudioProp);
             if (useLegacyAudioLogicProp.boolValue)
             {
                 EditorGUILayout.PropertyField(targetAudioSourceProp);


### PR DESCRIPTION
### Description
Added a toggle to Writer Audio so the Writer does not lerp audio while writing. This results in the volume being consistent while writing. 

Default and prefab Say Dialogs have this enabled so they will lerp audio by default. The user must change the prefab settings or create a custom Say Dialog to make use of this change.

### What is the current behavior?
Issue Number: #929 

When using a sound such as typewriters or other effects, the lerping audio can cause the sound to change volume rapidly and not sound consistent. This can be replicated by doing the following:

- Open the WritingSpeedTest scene
- Adjust the writers on the SayDialogs
     - Change beep sounds to contain only the MidVoice sound effect.
- Play the scene.

The sound modulates heavily as it stops and stops. With the other voices, it's not heard, but with one consistent sound effect, the effect is noticeable and causes peaks in the audio levels.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- When Lerp Writer Volume is enabled, the default lerp volume behaviour remains
- When Lerp Writer Volume is disabled, the writer remains at the target volume set by the Writer without lerping. 

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation 
     - Possibly, the variable may need to be added as well as a description of what it does. There is a tooltip in the editor that is thorough.

- My change modifies the runtime execution/behaviour of existing Fungus Features. e.g., Say, Menus, Portraits, etc.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

This is a rehash of #934 , but without the stupid mistake that has messed up all of my other PR's. I swear, I know how to use Git.

![Setting in editor](https://user-images.githubusercontent.com/31874317/103201338-4d69ec80-48b5-11eb-9611-3a3a18fe474d.png)