### PR TITLE
New Feature: Is Active and Is Inactive commands for game objects

### DIFF
--- a/Assets/Fungus/Scripts/Commands/IsActive.cs
+++ b/Assets/Fungus/Scripts/Commands/IsActive.cs
@@ -7,7 +7,7 @@ namespace Fungus
     /// <summary>
     /// Sets a game object in the scene to be active / inactive.
     /// </summary>
-    [CommandInfo("Scripting",
+    [CommandInfo("Flow",
                  "Is Active",
                  "Checks if an object is active in the scene.\n" +
                 "If 'ignoreParent' is true, this command will only return the state of the object independent of the parent." +

--- a/Assets/Fungus/Scripts/Commands/IsActive.cs
+++ b/Assets/Fungus/Scripts/Commands/IsActive.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Fungus
+{
+    /// <summary>
+    /// Sets a game object in the scene to be active / inactive.
+    /// </summary>
+    [CommandInfo("Scripting",
+                 "Is Active",
+                 "Checks if an object is active in the scene.\n" +
+                "If 'ignoreParent' is true, this command will only return the state of the object independent of the parent." +
+                "\nLeave this as true unless you really need to check activeInHierarchy")]
+    [AddComponentMenu("")]
+    [ExecuteInEditMode]
+    public class IsActive : Condition
+    {
+        [Tooltip("Reference of game object to check")]
+        [SerializeField] protected GameObjectData targetObject;
+
+        [Tooltip("The state you want to check. If true, will check if object is active")]
+        [SerializeField] protected BooleanData activeState = new BooleanData(true);
+
+        [Tooltip("If enabled, the state of the object itself will be returned. This means even if the parent is disabled, if the selected object is active, that will be returned.\n" +
+            "Leave enabled unless you need the parents' state too")]
+        [SerializeField] protected bool ignoreParent = true;
+
+        protected override bool EvaluateCondition()
+        {
+            if (ignoreParent) return targetObject.Value.activeSelf == activeState;
+
+            else return targetObject.Value.activeInHierarchy == activeState;
+        }
+
+        public override string GetSummary()
+        {
+            if (targetObject.Value == null) return "Error: no target object assigned!";
+
+            string state = activeState == true ? "active" : "inactive";
+            string hierarchy = ignoreParent == true ? " in hierarchy, ignoring parent" : string.Empty;
+            return "Is " + targetObject.Value.name + " " + state + hierarchy + "?";
+        }
+
+        public override bool HasReference(Variable variable)
+        {
+            return targetObject.gameObjectRef == variable || activeState.booleanRef == variable ||
+                base.HasReference(variable);
+        }
+
+    }
+}

--- a/Assets/Fungus/Scripts/Commands/IsActive.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/IsActive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0f1e069442418e4aa3951b0efe66004
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fungus/Scripts/Commands/IsInactive.cs
+++ b/Assets/Fungus/Scripts/Commands/IsInactive.cs
@@ -7,7 +7,7 @@ namespace Fungus
     /// <summary>
     /// Sets a game object in the scene to be active / inactive.
     /// </summary>
-    [CommandInfo("Scripting",
+    [CommandInfo("Flow",
                  "Is Inactive",
                  "Checks if an object is inactive (disabled) in the scene.\n" +
                 "If 'ignoreParent' is true, this command will only return the state of the object independent of the parent." +

--- a/Assets/Fungus/Scripts/Commands/IsInactive.cs
+++ b/Assets/Fungus/Scripts/Commands/IsInactive.cs
@@ -8,13 +8,13 @@ namespace Fungus
     /// Sets a game object in the scene to be active / inactive.
     /// </summary>
     [CommandInfo("Scripting",
-                 "Is Active",
-                 "Checks if an object is active in the scene.\n" +
+                 "Is Inactive",
+                 "Checks if an object is inactive (disabled) in the scene.\n" +
                 "If 'ignoreParent' is true, this command will only return the state of the object independent of the parent." +
                 "\nLeave this as true unless you really need to check activeInHierarchy")]
     [AddComponentMenu("")]
     [ExecuteInEditMode]
-    public class IsActive : Condition
+    public class IsInactive : Condition
     {
         [Tooltip("Reference of game object to check")]
         [SerializeField] protected GameObjectData targetObject;
@@ -25,9 +25,9 @@ namespace Fungus
 
         protected override bool EvaluateCondition()
         {
-            if (ignoreParent) return targetObject.Value.activeSelf == true;
+            if (ignoreParent) return targetObject.Value.activeSelf == false;
 
-            else return targetObject.Value.activeInHierarchy == true;
+            else return targetObject.Value.activeInHierarchy == false;
         }
 
         public override string GetSummary()
@@ -35,7 +35,7 @@ namespace Fungus
             if (targetObject.Value == null) return "Error: no target object assigned!";
 
             string hierarchy = ignoreParent == true ? " in hierarchy, ignoring parent" : string.Empty;
-            return "Is " + targetObject.Value.name + " active" + hierarchy + "?";
+            return "Is " + targetObject.Value.name + " inactive" + hierarchy + "?";
         }
 
         public override bool HasReference(Variable variable)

--- a/Assets/Fungus/Scripts/Commands/IsInactive.cs.meta
+++ b/Assets/Fungus/Scripts/Commands/IsInactive.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 945c8550235f02549861816f0c160cf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
Really simple. Added Is Active and Is Inactive commands that checks if a game object is active/inactive. Also has additional parameters on if it will ignore the parent (default) or not.

If the parent can be ignored, these commands use gameObject.activeSelf.
If the parent is included (ignoreParent = false), these commands use gameObject.activeInHierarchy instead.

### What is the current behavior?
Currently, there is no way to check if an object is active/inactive in Fungus. You can only set its state.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Add the necessary command.
- If you want to check if an object is inactive, you can set the state to false and the command will return true if the object is disabled
- Define your flow depending on what you want. They are conditional checks so they will return true/false and follow the flow afterwards.

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

Finally, a pull request that does not reference that accursed audio lerp fix.

![Screenshot_40](https://user-images.githubusercontent.com/31874317/123949177-e4e4f080-d967-11eb-8f47-147297ad889a.png)
