### PR TITLE
Fix can't scroll if camera's viewport rect is modified

### DIFF
--- a/Assets/Fungus/Scripts/Components/CameraManager.cs
+++ b/Assets/Fungus/Scripts/Components/CameraManager.cs
@@ -138,6 +138,8 @@ namespace Fungus
             }
 
             Vector3 cameraDelta = swipeCamera.ScreenToViewportPoint(delta);
+			cameraDelta.x = cameraDelta.x * swipeCamera.rect.width + swipeCamera.rect.x;
+			cameraDelta.y = cameraDelta.y * swipeCamera.rect.height + swipeCamera.rect.y;
             cameraDelta.x *= -2f * swipeSpeedMultiplier;
             cameraDelta.y *= -2f * swipeSpeedMultiplier;
             cameraDelta.z = 0f;


### PR DESCRIPTION
### Description
When the camera's rect doesn't use the whole screen, scrolling snaps to one of the screen sides. This fixes it.
A quick way to view this problem is to click on the camera and change any of the viewport values. After that, swipping will stop working.

### What is the current behavior?
If the camera's rect isn't the default one, the scroll on a swipe element will automatically be performed without any user input. This happens because it's assumed that the viewport matches the camera's viewport rect, but it isn't always true.

### What is the new behavior?
Now swipping always works instead of only when the screen rect is ok.

### Important Notes
None

### Other information
None