### PR TITLE
Adds sound volume control to SetAudioVolume. This ability needs in so…

### DIFF
--- a/Assets/Fungus/Scripts/Commands/SetAudioVolume.cs
+++ b/Assets/Fungus/Scripts/Commands/SetAudioVolume.cs
@@ -15,8 +15,12 @@ namespace Fungus
     public class SetAudioVolume : Command
     {
         [Range(0,1)]
-        [Tooltip("Global volume level for audio played using Play Music and Play Sound")]
-        [SerializeField] protected float volume = 1f;
+        [Tooltip("Global music volume level for audio played using Play Music")]
+        [SerializeField] protected float musicVolume = 1f;
+        
+        [Range(0,1)]
+        [Tooltip("Global sound volume level for audio played using Play Sound")]
+        [SerializeField] protected float soundVolume = 1f;
 
         [Range(0,30)]
         [Tooltip("Time to fade between current volume level and target volume level.")]
@@ -31,7 +35,7 @@ namespace Fungus
         {
             var musicManager = FungusManager.Instance.MusicManager;
 
-            musicManager.SetAudioVolume(volume, fadeDuration, () => {
+            musicManager.SetAudioVolume(musicVolume, soundVolume, fadeDuration, () => {
                 if (waitUntilFinished)
                 {
                     Continue();

--- a/Assets/Fungus/Scripts/Components/MusicManager.cs
+++ b/Assets/Fungus/Scripts/Components/MusicManager.cs
@@ -153,12 +153,13 @@ namespace Fungus
         }
 
         /// <summary>
-        /// Fades the game music volume to required level over a period of time.
+        /// Fades the game music and sound volume to required level over a period of time.
         /// </summary>
-        /// <param name="volume">The new music volume value [0..1]</param>
+        /// <param name="musicVolume">The new music volume value [0..1]</param>
+        /// <param name="soundVolume">The new sound volume value [0..1]</param>
         /// <param name="duration">The length of time in seconds needed to complete the volume change.</param>
         /// <param name="onComplete">Delegate function to call when fade completes.</param>
-        public virtual void SetAudioVolume(float volume, float duration, System.Action onComplete)
+        public virtual void SetAudioVolume(float musicVolume, float soundVolume, float duration, Action onComplete)
         {
             if (Mathf.Approximately(duration, 0f))
             {
@@ -166,23 +167,15 @@ namespace Fungus
                 {
                     onComplete();
                 }
-                audioSourceMusic.volume = volume;
-                audioSourceAmbiance.volume = volume;
-                return;
+                audioSourceMusic.volume = musicVolume;
+                audioSourceAmbiance.volume = musicVolume;
+                audioSourceSoundEffect.volume = soundVolume;
             }
-
-            LeanTween.value(gameObject,
-                audioSourceMusic.volume,
-                volume,
-                duration).setOnUpdate((v) => {
-                    audioSourceMusic.volume = v;
-                    audioSourceAmbiance.volume = v;
-                }).setOnComplete(() => {
-                    if (onComplete != null)
-                    {
-                        onComplete();
-                    }
-                });
+            else
+            {
+                SetSoundVolume(soundVolume, duration);
+                SetMusicVolume(musicVolume, duration, onComplete);
+            }
         }
 
         /// <summary>
@@ -203,6 +196,44 @@ namespace Fungus
             audioSourceAmbiance.clip = null;
         }
 
+        /// <summary>
+        /// Fades the game music volume to required level over a period of time.
+        /// </summary>
+        /// <param name="musicVolume">The new music volume value [0..1]</param>
+        /// <param name="duration">The length of time in seconds needed to complete the volume change.</param>
+        /// <param name="onComplete">Delegate function to call when fade completes.</param>
+        private void SetMusicVolume(float musicVolume, float duration, Action onComplete)
+        {
+            LeanTween.value(gameObject,
+                audioSourceMusic.volume,
+                musicVolume,
+                duration).setOnUpdate((v) => {
+                audioSourceMusic.volume = v;
+                audioSourceAmbiance.volume = v;
+            }).setOnComplete(() => {
+                if (onComplete != null)
+                {
+                    onComplete();
+                }
+            });
+        }
+        
+        /// <summary>
+        /// Fades the game sound volume to required level over a period of time.
+        /// </summary>
+        /// <param name="soundVolume">The new sound volume value [0..1]</param>
+        /// <param name="duration">The length of time in seconds needed to complete the volume change.</param>
+        private void SetSoundVolume(float soundVolume, float duration)
+        {
+            LeanTween.value(gameObject,
+                audioSourceSoundEffect.volume,
+                soundVolume,
+                duration).setOnUpdate((v) =>
+            {
+                audioSourceSoundEffect.volume = v;
+            });
+        }
+        
         #endregion
     }
 }


### PR DESCRIPTION
### Description
<!-- Please describe your pull request. Is it a bug fix, a new feature, code refactor, documentation update, etc.-->
Adds sound volume control to SetAudioVolume. This ability needs in some cases.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, and link to a relevant issue. 
Issue Number: N/A
-->
When we set volume in SetAudioVolume, only music (and ambience?) volume changed.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Now sound volume changed with music sound if it's nessesary

### Important Notes
<!--- Go over the following points, and delete all lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change require modifcations or additions to documentation
- My change modifies the workflow/editing of flowcharts/blocks/commands etc.
- My change modifies the runtime execution/behaviour of existing Fungus Features. e.g., Say, Menus, Portraits, etc.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

<!-- Any other information that is important to this PR such as screenshots, gifs, video of before and after the change are always great -->
