### PR TITLE
[WIP] Add toggle to allow Fungus to run on unscaled time. Take 2.

### DIFF
--- a/Assets/Fungus/Scripts/Commands/AudioMixerSnapshotTransitionTo.cs
+++ b/Assets/Fungus/Scripts/Commands/AudioMixerSnapshotTransitionTo.cs
@@ -37,7 +37,7 @@ namespace Fungus
 
         protected IEnumerator WaitForTransition()
         {
-            yield return new WaitForSeconds(timeToReach.Value);
+            yield return FungusManager.WaitForAdjustedTime(timeToReach.Value);
             Continue();
         }
 

--- a/Assets/Fungus/Scripts/Commands/AudioMixerTransitionToSnapshots.cs
+++ b/Assets/Fungus/Scripts/Commands/AudioMixerTransitionToSnapshots.cs
@@ -50,7 +50,7 @@ namespace Fungus
 
         protected IEnumerator WaitForTransition()
         {
-            yield return new WaitForSeconds(timeToTransition.Value);
+            yield return FungusManager.WaitForAdjustedTime(timeToTransition.Value);
             Continue();
         }
 

--- a/Assets/Fungus/Scripts/Commands/AudioSourcePlay.cs
+++ b/Assets/Fungus/Scripts/Commands/AudioSourcePlay.cs
@@ -65,7 +65,7 @@ namespace Fungus
 
         protected IEnumerator WaitForClipLength()
         {
-            yield return new WaitForSeconds(audioSource.Value.clip.length);
+            yield return FungusManager.WaitForAdjustedTime(audioSource.Value.clip.length);
             Continue();
         }
 

--- a/Assets/Fungus/Scripts/Commands/AudioSourcePlayOneShot.cs
+++ b/Assets/Fungus/Scripts/Commands/AudioSourcePlayOneShot.cs
@@ -40,7 +40,7 @@ namespace Fungus
 
         protected IEnumerator WaitForClipLength()
         {
-            yield return new WaitForSeconds(audioClip.Value.length);
+            yield return FungusManager.WaitForAdjustedTime(audioClip.Value.length);
             Continue();
         }
 

--- a/Assets/Fungus/Scripts/Components/Block.cs
+++ b/Assets/Fungus/Scripts/Components/Block.cs
@@ -336,7 +336,7 @@ namespace Fungus
                 #if UNITY_EDITOR
                 if (flowchart.StepPause > 0f)
                 {
-                    yield return new WaitForSeconds(flowchart.StepPause);
+                    yield return FungusManager.WaitForAdjustedTime(flowchart.StepPause);
                 }
                 #endif
 

--- a/Assets/Fungus/Scripts/Components/DialogInput.cs
+++ b/Assets/Fungus/Scripts/Components/DialogInput.cs
@@ -139,7 +139,7 @@ namespace Fungus
 
             if (ignoreClickTimer > 0f)
             {
-                ignoreClickTimer = Mathf.Max (ignoreClickTimer - Time.deltaTime, 0f);
+                ignoreClickTimer = Mathf.Max (ignoreClickTimer - FungusManager.deltaTime, 0f);
             }
 
             if (ignoreMenuClicks)

--- a/Assets/Fungus/Scripts/Components/FungusManager.cs
+++ b/Assets/Fungus/Scripts/Components/FungusManager.cs
@@ -24,6 +24,11 @@ namespace Fungus
         static bool applicationIsQuitting = false;
         readonly static object _lock = new object();  // The keyword "readonly" is friendly to the multi-thread.
 
+        public static bool useUnscaledTime = false;
+        public static float deltaTime => useUnscaledTime ? Time.unscaledDeltaTime : Time.deltaTime;
+        public static object WaitForAdjustedTime(float seconds) =>
+            useUnscaledTime ? new WaitForSecondsRealtime(seconds) : new WaitForSeconds(seconds);
+
         void Awake()
         {
             if (instance == null)

--- a/Assets/Fungus/Scripts/Components/MenuDialog.cs
+++ b/Assets/Fungus/Scripts/Components/MenuDialog.cs
@@ -138,7 +138,7 @@ namespace Fungus
                     timeoutSlider.value = t;
                 }
 
-                elapsedTime += Time.deltaTime;
+                elapsedTime += FungusManager.deltaTime;
 
                 yield return null;
             }
@@ -373,7 +373,7 @@ namespace Fungus
                     timeoutSlider.value = t;
                 }
 
-                elapsedTime += Time.deltaTime;
+                elapsedTime += FungusManager.deltaTime;
 
                 yield return null;
             }

--- a/Assets/Fungus/Scripts/Components/PortraitController.cs
+++ b/Assets/Fungus/Scripts/Components/PortraitController.cs
@@ -255,7 +255,7 @@ namespace Fungus
             waitTimer = duration;
             while (waitTimer > 0f)
             {
-                waitTimer -= Time.deltaTime;
+                waitTimer -= FungusManager.deltaTime;
                 yield return null;
             }
 

--- a/Assets/Fungus/Scripts/Components/SayDialog.cs
+++ b/Assets/Fungus/Scripts/Components/SayDialog.cs
@@ -211,7 +211,7 @@ namespace Fungus
             {
                 // Add a short delay before we start fading in case there's another Say command in the next frame or two.
                 // This avoids a noticeable flicker between consecutive Say commands.
-                fadeCoolDownTimer = Mathf.Max(0f, fadeCoolDownTimer - Time.deltaTime);
+                fadeCoolDownTimer = Mathf.Max(0f, fadeCoolDownTimer - FungusManager.deltaTime);
             }
 
             CanvasGroup canvasGroup = GetCanvasGroup();
@@ -221,7 +221,7 @@ namespace Fungus
             }
             else
             {
-                float delta = (1f / fadeDuration) * Time.deltaTime;
+                float delta = (1f / fadeDuration) * FungusManager.deltaTime;
                 float alpha = Mathf.MoveTowards(canvasGroup.alpha, targetAlpha, delta);
                 canvasGroup.alpha = alpha;
 

--- a/Assets/Fungus/Scripts/Components/SpriteFader.cs
+++ b/Assets/Fungus/Scripts/Components/SpriteFader.cs
@@ -31,7 +31,7 @@ namespace Fungus
 
         protected virtual void Update() 
         {
-            fadeTimer += Time.deltaTime;
+            fadeTimer += FungusManager.deltaTime;
             if (fadeTimer > fadeDuration)
             {
                 // Snap to final values

--- a/Assets/Fungus/Scripts/Components/Writer.cs
+++ b/Assets/Fungus/Scripts/Components/Writer.cs
@@ -554,7 +554,7 @@ namespace Fungus
             UpdateOpenMarkup();
             UpdateCloseMarkup();
 
-            float timeAccumulator = Time.deltaTime;
+            float timeAccumulator = FungusManager.deltaTime;
             float invWritingSpeed = 1f / currentWritingSpeed;
 
             //refactor this, its mostly the same 30 lines of code
@@ -598,8 +598,8 @@ namespace Fungus
                         timeAccumulator -= invWritingSpeed;
                         if (timeAccumulator <= 0f)
                         {
-                            var waitTime = Mathf.Max(invWritingSpeed, Time.deltaTime);
-                            yield return new WaitForSeconds(waitTime);
+                            var waitTime = Mathf.Max(invWritingSpeed, FungusManager.deltaTime);
+                            yield return FungusManager.WaitForAdjustedTime(waitTime);
                             timeAccumulator += waitTime;
                         }
                     }
@@ -647,8 +647,8 @@ namespace Fungus
                         timeAccumulator -= invWritingSpeed;
                         if (timeAccumulator <= 0f)
                         {
-                            var waitTime = Mathf.Max(invWritingSpeed, Time.deltaTime);
-                            yield return new WaitForSeconds(waitTime);
+                            var waitTime = Mathf.Max(invWritingSpeed, FungusManager.deltaTime);
+                            yield return FungusManager.WaitForAdjustedTime(waitTime);
                             timeAccumulator += waitTime;
                         }
                     }
@@ -765,7 +765,7 @@ namespace Fungus
                     break;
                 }
 
-                timeRemaining -= Time.deltaTime;
+                timeRemaining -= FungusManager.deltaTime;
                 yield return null;
             }
 

--- a/Assets/Fungus/Scripts/Components/WriterAudio.cs
+++ b/Assets/Fungus/Scripts/Components/WriterAudio.cs
@@ -220,7 +220,7 @@ namespace Fungus
         protected virtual void Update()
         {
             if(lastUsedAudioSource != null)
-                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, Time.deltaTime * 5f);
+                lastUsedAudioSource.volume = Mathf.MoveTowards(lastUsedAudioSource.volume, targetVolume, FungusManager.deltaTime * 5f);
         }
 
         #region IWriterListener implementation

--- a/Assets/Fungus/Scripts/Editor/BlockEditor.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockEditor.cs
@@ -838,7 +838,7 @@ namespace Fungus.EditorUtils
 
         protected IEnumerator RunBlock(Flowchart flowchart, Block targetBlock, int commandIndex, float delay)
         {
-            yield return new WaitForSeconds(delay);
+            yield return FungusManager.WaitForAdjustedTime(delay);
             flowchart.ExecuteBlock(targetBlock, commandIndex);
         }
 

--- a/Assets/Fungus/Thirdparty/FungusLua/Scripts/Components/ExecuteHandler.cs
+++ b/Assets/Fungus/Thirdparty/FungusLua/Scripts/Components/ExecuteHandler.cs
@@ -99,11 +99,11 @@ namespace Fungus
 
         protected IEnumerator ExecutePeriodically()
         {
-            yield return new WaitForSeconds(executeAfterTime);
+            yield return FungusManager.WaitForAdjustedTime(executeAfterTime);
             Execute(ExecuteMethod.AfterPeriodOfTime);
             while (repeatExecuteTime)
             {
-                yield return new WaitForSeconds(repeatEveryTime);
+                yield return FungusManager.WaitForAdjustedTime(repeatEveryTime);
                 Execute(ExecuteMethod.AfterPeriodOfTime);
             }
         }

--- a/Assets/Fungus/Thirdparty/LeanTween/LeanTween.cs
+++ b/Assets/Fungus/Thirdparty/LeanTween/LeanTween.cs
@@ -381,7 +381,7 @@ public class LeanTween : MonoBehaviour {
             //      Debug.Log("Time.unscaledDeltaTime:"+Time.unscaledDeltaTime);
             #endif
 
-            dtActual = Time.deltaTime;
+            dtActual = FungusManager.deltaTime;
             maxTweenReached = 0;
             finishedCnt = 0;
             // if(tweenMaxSearch>1500)

--- a/Assets/Fungus/Thirdparty/iTween/iTween.cs
+++ b/Assets/Fungus/Thirdparty/iTween/iTween.cs
@@ -4569,7 +4569,7 @@ public class iTween : MonoBehaviour{
 	
 	IEnumerator TweenDelay(){
 		delayStarted = Time.time;
-		yield return new WaitForSeconds (delay);
+		yield return FungusManager.WaitForAdjustedTime(delay);
 		if(wasPaused){
 			wasPaused=false;
 			TweenStart();	
@@ -4600,7 +4600,7 @@ public class iTween : MonoBehaviour{
 	IEnumerator TweenRestart(){
 		if(delay > 0){
 			delayStarted = Time.time;
-			yield return new WaitForSeconds (delay);
+			yield return FungusManager.WaitForAdjustedTime(delay);
 		}
 		loop=true;
 		TweenStart();
@@ -4701,7 +4701,7 @@ public class iTween : MonoBehaviour{
 	/// </param>
 	public static Vector3 Vector3Update(Vector3 currentValue, Vector3 targetValue, float speed){
 		Vector3 diff = targetValue - currentValue;
-		currentValue += (diff * speed) * Time.deltaTime;
+		currentValue += (diff * speed) * FungusManager.deltaTime;
 		return (currentValue);
 	}
 	
@@ -4722,7 +4722,7 @@ public class iTween : MonoBehaviour{
 	/// </param>
 	public static Vector2 Vector2Update(Vector2 currentValue, Vector2 targetValue, float speed){
 		Vector2 diff = targetValue - currentValue;
-		currentValue += (diff * speed) * Time.deltaTime;
+		currentValue += (diff * speed) * FungusManager.deltaTime;
 		return (currentValue);
 	}
 	
@@ -4743,7 +4743,7 @@ public class iTween : MonoBehaviour{
 	/// </param>
 	public static float FloatUpdate(float currentValue, float targetValue, float speed){
 		float diff = targetValue - currentValue;
-		currentValue += (diff * speed) * Time.deltaTime;
+		currentValue += (diff * speed) * FungusManager.deltaTime;
 		return (currentValue);
 	}
 	
@@ -6929,7 +6929,7 @@ public class iTween : MonoBehaviour{
 	        }
 	        else
 	        {
-	            runningTime += Time.deltaTime;
+	            runningTime += FungusManager.deltaTime;
 	        }
 	
 			if(reverse){

--- a/Assets/FungusExamples/FungusLua/Bindings/CustomScript.cs
+++ b/Assets/FungusExamples/FungusLua/Bindings/CustomScript.cs
@@ -19,7 +19,7 @@ public class CustomScript : MonoBehaviour
     {
         Debug.Log("Called my coroutine");
 
-        yield return new WaitForSeconds(timeToWait);
+        yield return FungusManager.WaitForAdjustedTime(timeToWait);
 
         Debug.Log("Coroutine finished");
     }


### PR DESCRIPTION
Description

These changes enable Fungus to run while Time.timeScale == 0.
What is the current behavior?

If Time.timeScale is set to 0 Fungus is paused and uninteractable
What is the new behavior?

I made these changes, sans switch, for a project where I used Fungus for all the menus. I needed to pause 3d gameplay but have a character come up to act as the pause screen menu.

Behaviour Now:

    Fungus remains interactable while Time.timeScale == 0

Important Notes

    My change require modifcations or additions to documentation
    My change modifies the runtime execution/behaviour of existing Fungus Features. e.g., Say, Menus, Portraits, etc.
    My change adds demos to FungusExamples -- coming soon

Other information

Still a work in progress:

    Need advising on location of behaviour switch (currently FungusManager.cs)