### PR TITLE
Fixed: Keyboard App causes Block inspector to reset height

### DIFF
--- a/Assets/Fungus/Scripts/Editor/BlockInspector.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockInspector.cs
@@ -107,6 +107,10 @@ namespace Fungus.EditorUtils
             }        
 
             float width = EditorGUIUtility.currentViewWidth;
+            if (windowHeight == 0)
+            {
+                UpdateWindowHeight();
+            }
 
             blockScrollPos = GUILayout.BeginScrollView(blockScrollPos, GUILayout.Height(flowchart.BlockViewHeight));
             activeBlockEditor.DrawBlockName(flowchart);

--- a/Assets/Fungus/Scripts/Editor/BlockInspector.cs
+++ b/Assets/Fungus/Scripts/Editor/BlockInspector.cs
@@ -104,9 +104,7 @@ namespace Fungus.EditorUtils
             {
                 DestroyImmediate(activeBlockEditor);
                 activeBlockEditor = Editor.CreateEditor(block, typeof(BlockEditor)) as BlockEditor;
-            }
-
-            UpdateWindowHeight();
+            }        
 
             float width = EditorGUIUtility.currentViewWidth;
 
@@ -216,6 +214,11 @@ namespace Fungus.EditorUtils
                 }
             }
 
+            if (resize)
+            {
+                UpdateWindowHeight();
+            }
+
             if (resize && Event.current.type == EventType.Repaint)
             {
                 Undo.RecordObject(flowchart, "Resize view");
@@ -255,8 +258,8 @@ namespace Fungus.EditorUtils
             {
                 // Make sure block view is always clamped to visible area
                 float height = flowchart.BlockViewHeight;
-                height = Mathf.Max(200, height);
-                height = Mathf.Min(windowHeight - 200,height);
+                height = Mathf.Max(windowHeight / 8, height);
+                height = Mathf.Min(windowHeight - windowHeight / 8,height);
                 flowchart.BlockViewHeight = height;
             }
             


### PR DESCRIPTION
### Description

**Bug Description**
When using Chinese/Japanese/Korean input methods (IME) in Fungus editor:

The Block window jumps unexpectedly during text confirmation

Height flickering occurs for 2-3 frames after IME composition

Disrupts user workflow in editor operations

**Root Cause**
In BlockInspector.cs:

The windowHeight value directly tracked UnityEngine.Screen.height in real-time

During IME confirmation (2-3 frames), Screen.  height temporarily reports reduced window size values.  I not sure the ture reason, maybe is UnityEngine's bug.

https://github.com/user-attachments/assets/56c9092e-b99d-49a3-ae93-08eb11a565b9


This caused automatic unwanted layout recalculations

**Solution**
Modified window height update logic to:

Only update windowHeight when we need it.
